### PR TITLE
Simplificación en la representación de los modelos de aulas

### DIFF
--- a/app_reservas/models/Aula.py
+++ b/app_reservas/models/Aula.py
@@ -17,7 +17,7 @@ class Aula(models.Model):
 
     # Representación del objeto
     def __str__(self):
-        return 'Aula %s - Nivel %s - Cuerpo %s' % (self.numero, self.nivel.numero, self.nivel.cuerpo.numero)
+        return 'Aula %s - %s' % (self.numero, self.nivel)
 
     # Información de la clase
     class Meta:

--- a/app_reservas/models/Nivel.py
+++ b/app_reservas/models/Nivel.py
@@ -11,7 +11,7 @@ class Nivel(models.Model):
 
     # Representación del objeto
     def __str__(self):
-        return 'Nivel %s - Cuerpo %s' % (self.numero, self.cuerpo.numero)
+        return 'Nivel %s - %s' % (self.numero, self.cuerpo)
 
     # Información de la clase
     class Meta:


### PR DESCRIPTION
Se modificó la **representación de modelos**, para hacer uso de las representaciones de los modelos asociados, en vez de duplicar el formato utilizado.
