### PR TITLE
Instalación de Django-Bower y Timetable.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Directorio de componentes instalados por Django-Bower
+/components
+
+
+##########
+# Python #
+##########
+# Fuente: https://raw.githubusercontent.com/github/gitignore/master/Python.gitignore
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Django==1.8.5
+django-bower==5.0.4
 gunicorn==19.3.0
+six==1.10.0

--- a/reservas/settings.py
+++ b/reservas/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'djangobower',
     'app_reservas',
 )
 
@@ -101,4 +102,18 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
 STATIC_URL = '/static/'
+
+STATICFILES_FINDERS = (
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'djangobower.finders.BowerFinder',
+)
+
+BOWER_COMPONENTS_ROOT = os.path.join(BASE_DIR, 'components')
+
+BOWER_INSTALLED_APPS = (
+    'timetable',
+)


### PR DESCRIPTION
Se instala `Django-Bower` para poder instalar dependencias de Bower. Además, se instala la librería [**timetable.js**](https://github.com/Grible/timetable.js) mediante Bower.
