### PR TITLE
Instalación de Bootswatch Flatly y Fullcalendar-Scheduler

### DIFF
--- a/reservas/settings.py
+++ b/reservas/settings.py
@@ -115,5 +115,7 @@ STATICFILES_FINDERS = (
 BOWER_COMPONENTS_ROOT = os.path.join(BASE_DIR, 'components')
 
 BOWER_INSTALLED_APPS = (
-    'timetable',
+    'bootswatch-dist#flatly',
+    'fullcalendar-scheduler',
+    'jquery',
 )


### PR DESCRIPTION
Se instala, mediante _Bower_, las aplicaciones **Bootswatch (_Flatly_)** **[1]**, **Fullcalendar-Scheduler** **[2]** y **jQuery** **[3]**. Además, se desinstala **Timetable.js**.

**[1]** https://bootswatch.com/flatly/
**[2]** http://fullcalendar.io/scheduler/
**[3]** https://jquery.com/
