### PR TITLE
Creación de archivo de configuración privada

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-# Directorio de componentes instalados por Django-Bower
+# Archivo de configuración privada del proyecto.
+/reservas/private_settings.py
+
+# Directorio de componentes instalados por Django-Bower.
 /components
 
 

--- a/reservas/private_settings.template.py
+++ b/reservas/private_settings.template.py
@@ -1,0 +1,6 @@
+# Editar este archivo para configurar la aplicación, y luego renombrarlo a
+# 'private_settings.py'.
+
+# Token de Google Calendar, utilizado para consultar la información de eventos
+# de los calendarios de Google Calendar.
+GOOGLE_CALENDAR_TOKEN = ''

--- a/reservas/settings.py
+++ b/reservas/settings.py
@@ -119,3 +119,5 @@ BOWER_INSTALLED_APPS = (
     'fullcalendar-scheduler',
     'jquery',
 )
+
+from .private_settings import *


### PR DESCRIPTION
Se crea el archivo de configuración privada `private_settings.py`, y una plantilla del mismo (`private_settings.template.py`), para no subir la configuración privada al repositorio.
