### PR TITLE
Instalación de Google API y 'django-regex-field' mediante pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,14 @@
 Django==1.8.5
 django-bower==5.0.4
+django-regex-field==0.2.0
+google-api-python-client==1.4.2
 gunicorn==19.3.0
+httplib2==0.9.2
+oauth2client==1.5.2
+pyasn1==0.1.9
+pyasn1-modules==0.0.8
+python-dateutil==2.4.2
+rsa==3.2.3
+simplejson==3.8.1
 six==1.10.0
+uritemplate==0.6


### PR DESCRIPTION
Se instala `google-api-python-client` (junto a sus dependencias) y `django-regex-field`, mediante **pip**.
