### PR TITLE
Eliminación de dependencia 'django-regex-field'

### DIFF
--- a/app_facturacion/migrations/0002_auto_20151203_2320.py
+++ b/app_facturacion/migrations/0002_auto_20151203_2320.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('app_facturacion', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='tipoconceptoregex',
+            name='regex',
+            field=models.CharField(max_length=128),
+        ),
+    ]

--- a/app_facturacion/models/TipoConceptoRegex.py
+++ b/app_facturacion/models/TipoConceptoRegex.py
@@ -1,12 +1,11 @@
 # coding=utf-8
 
 from django.db import models
-from regex_field import RegexField
 
 
 class TipoConceptoRegex(models.Model):
     # Atributos
-    regex = RegexField(max_length=128)
+    regex = models.CharField(max_length=128)
     # Relaciones
     tipo_concepto = models.ForeignKey('TipoConcepto')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Django==1.8.5
 django-bower==5.0.4
-django-regex-field==0.2.0
 google-api-python-client==1.4.2
 gunicorn==19.3.0
 httplib2==0.9.2


### PR DESCRIPTION
Debido a problemas con **django-regex-field** (issue 14 en ambitioninc/django-regex-field), se desinstala y se cambia el tipo del atributo **regex** a **CharField**.
