### PR TITLE
Corrección de BASE_DIR

### DIFF
--- a/reservas/settings/base.py
+++ b/reservas/settings/base.py
@@ -15,8 +15,7 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/


### PR DESCRIPTION
Se corrige el armado de **BASE_DIR**, ya que al crear el paquete `settings`, es necesario actualizarlo para que apunte al directorio raiz del proyecto, y no a un nivel inferior de directorios.
