### PR TITLE
Configuración de buildpacks para Heroku

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/heroku/heroku-buildpack-nodejs.git
+https://github.com/amanjain/heroku-buildpack-python-with-django-bower.git


### PR DESCRIPTION
Se especifican los **buildpacks de Heroku**, para hacer uso de _Node.js_ y _Django-Bower_.
