### PR TITLE
Especificación de dependencia de Bower, en package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "bower": "~1.7.0"
+  }
+}


### PR DESCRIPTION
Se añade el archivo `package.json`, propio de Node.js, indicando la dependencia de **Bower**, para su instalación mediante el _buildpack_ de Node.js de Heroku.
