### PR TITLE
Creación de plantilla 'index' para aplicación de reservas

### DIFF
--- a/app_reservas/views.py
+++ b/app_reservas/views.py
@@ -48,7 +48,7 @@ def cuerpo_detalle(request, num_cuerpo):
 def index(request):
     return render(
         request,
-        'app_reservas/base.html'
+        'app_reservas/index.html'
     )
 
 def solicitud_aula(request):

--- a/templates/app_reservas/index.html
+++ b/templates/app_reservas/index.html
@@ -1,0 +1,23 @@
+{% extends 'app_reservas/base.html' %}
+{% load static %}
+
+{% block static_css %}
+{% endblock %}
+
+{% block static_js %}
+{% endblock %}
+
+{% block title %}
+    Administración de aulas
+{% endblock %}
+
+{% block contenido %}
+
+    <h1 style="text-align: center;">Administración de aulas</h1>
+
+    <p class="text-center">
+    ¡Bienvenido! En este sitio podrá consultar las reservas de aulas pertenecientes a la Facultad Regional Mendoza,
+    Universidad Tecnológica Nacional.
+    </p>
+
+{% endblock %}


### PR DESCRIPTION
Se añade la plantilla `index` para la aplicación de **reservas**, accesible desde `/reservas`.
