### PR TITLE
Visualización del detalle de un área

### DIFF
--- a/app_reservas/migrations/0002_area_slug.py
+++ b/app_reservas/migrations/0002_area_slug.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('app_reservas', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='area',
+            name='slug',
+            field=models.SlugField(default='Slug'),
+            preserve_default=False,
+        ),
+    ]

--- a/app_reservas/models/Area.py
+++ b/app_reservas/models/Area.py
@@ -6,6 +6,7 @@ from django.db import models
 class Area(models.Model):
     # Atributos
     nombre = models.CharField(max_length=50)
+    slug = models.SlugField(max_length=50)
 
     # Representación del objeto
     def __str__(self):

--- a/app_reservas/urls.py
+++ b/app_reservas/urls.py
@@ -24,6 +24,11 @@ urlpatterns = [
         name='aula_detalle'
     ),
     url(
+        r'^area/(?P<slug_area>[A-Za-z0-9]+)/$',
+        views.area_detalle,
+        name='area_detalle'
+    ),
+    url(
         r'^solicitud/aula/$',
         views.solicitud_aula,
         name='solicitud_aula'

--- a/app_reservas/views.py
+++ b/app_reservas/views.py
@@ -1,6 +1,20 @@
+# coding=utf-8
+
 from django.shortcuts import get_object_or_404, render
 
-from .models import Aula, Cuerpo, Nivel
+from .models import Area, Aula, Cuerpo, Nivel
+
+
+def area_detalle(request, slug_area):
+    # Obtiene el área por su nombre.
+    area = get_object_or_404(Area, slug=slug_area)
+    return render(
+        request,
+        'app_reservas/area_detalle.html',
+        {
+            'area': area,
+        }
+    )
 
 
 def aula_detalle(request, num_cuerpo, num_nivel, num_aula):

--- a/templates/app_reservas/area_detalle.html
+++ b/templates/app_reservas/area_detalle.html
@@ -1,0 +1,57 @@
+{% extends 'app_reservas/base.html' %}
+{% load static %}
+
+{% block static_css %}
+    <!--Fullcalendar-Scheduler-->
+    <link rel='stylesheet' href='{% static 'fullcalendar/dist/fullcalendar.css' %}' />
+    <link rel='stylesheet' href='{% static 'fullcalendar-scheduler/dist/scheduler.css' %}' />
+    <script src='{% static 'moment/moment.js' %}'></script>
+    <script src='{% static 'jquery/dist/jquery.js' %}'></script>
+    <script src='{% static 'fullcalendar/dist/fullcalendar.js' %}'></script>
+    <script src='{% static 'fullcalendar/dist/lang/es.js' %}'></script>
+    <script src='{% static 'fullcalendar-scheduler/dist/scheduler.js' %}'></script>
+{% endblock %}
+
+{% block title %}
+    Área: {{ area }}
+{% endblock %}
+
+{% block contenido %}
+
+<h1 style="text-align: center;">{{ area }}</h1>
+
+<br />
+<br />
+
+<div id="calendar"></div>
+
+{% comment %}
+<script>
+    var current_date = new Date();
+    var last_hour = (current_date.getHours() - 1) + ":00:00";
+
+    $('#calendar').fullCalendar({
+        defaultView: 'timelineDay',
+        schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
+        lang: 'es',
+        resources: [
+            {
+                id: '{{ aula.id }}',
+                title: '{{ aula.get_nombre_corto }}',
+            },
+        ],
+        events: [
+            {% for evento in aula.get_eventos %}
+                {
+                    title: '{{ evento.titulo }}',
+                    start: '{{ evento.inicio_str }}',
+                    end: '{{ evento.fin_str }}',
+                    resourceId: '{{ aula.id }}',
+                },
+            {% endfor %}
+        ],
+        minTime: last_hour,
+    });
+</script>
+{% endcomment %}
+{% endblock %}

--- a/templates/app_reservas/base.html
+++ b/templates/app_reservas/base.html
@@ -11,7 +11,7 @@
     <meta name="author" content="">
     <!--<link rel="icon" href="../../favicon.ico">-->
 
-    <title>{% block title %}Fixed Top Navbar Example for Bootstrap{% endblock %}</title>
+    <title>{% block title %}Administración de aulas{% endblock %}</title>
 
     <!-- Bootstrap core CSS -->
     <link rel="stylesheet" href='{% static 'bootswatch-dist/css/bootstrap.min.css' %}'>


### PR DESCRIPTION
Se añade la vista del **detalle de un área**. Para poder especificar el área en el URL, se le agrega el atributo `slug` al modelo `Area`, que indica un nombre amigable para ser usado en direcciones URL.
