### PR TITLE
Configuración de recursos estáticos, para su uso desde Heroku

### DIFF
--- a/reservas/settings/production.py
+++ b/reservas/settings/production.py
@@ -8,3 +8,13 @@ from .base import *
 DEBUG = False
 ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', '*')
 DATABASES['default'] = dj_database_url.config()
+
+# Configuración de recursos estáticos, para su uso desde Heroku.
+# Fuente: https://devcenter.heroku.com/articles/django-assets
+STATIC_ROOT = 'staticfiles'
+STATIC_URL = '/static/'
+
+STATICFILES_DIRS = (
+    os.path.join(BASE_DIR, 'static'),
+)
+


### PR DESCRIPTION
Se especifica en el archivo de **configuración de producción**, las variables destinadas al funcionamiento de los **recursos estáticos** desde Heroku **[1]**.

**[1]** [Django and Static Assets](https://devcenter.heroku.com/articles/django-assets)
