### PR TITLE
Instalación y configuración de 'whitenoise'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ rsa==3.2.3
 simplejson==3.8.1
 six==1.10.0
 uritemplate==0.6
+whitenoise==2.0.6

--- a/reservas/settings/base.py
+++ b/reservas/settings/base.py
@@ -114,6 +114,8 @@ STATICFILES_FINDERS = (
     'djangobower.finders.BowerFinder',
 )
 
+STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
+
 BOWER_COMPONENTS_ROOT = os.path.join(BASE_DIR, 'components')
 
 BOWER_INSTALLED_APPS = (

--- a/reservas/wsgi.py
+++ b/reservas/wsgi.py
@@ -10,7 +10,10 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from whitenoise.django import DjangoWhiteNoise
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "reservas.settings")
 
 application = get_wsgi_application()
+application = DjangoWhiteNoise(application)
+


### PR DESCRIPTION
Se instala y se configura **whitenoise** **[1]**, para servir recursos estáticos en entornos de producción de Django. **[2]**

**[1]** [whitenoise](https://warehouse.python.org/project/whitenoise/)
**[2]** [Using WhiteNoise with Django](http://whitenoise.evans.io/en/latest/django.html)
