### PR TITLE
Creación de configuración para entorno de desarrollo

### DIFF
--- a/reservas/settings/development.py
+++ b/reservas/settings/development.py
@@ -1,0 +1,9 @@
+# coding=utf-8
+
+from .production import *
+
+# Archivo de configuración de desarrollo. Se basa en la configuración de
+# producción, y permite determinar el estado del Debug mediante la variable de
+# entorno 'DJANGO_DEBUG'.
+DEBUG = bool(os.environ.get('DJANGO_DEBUG', ''))
+


### PR DESCRIPTION
Se crea un archivo de **configuración para entornos de desarrollo**. Actualmente, se basa en la configuración de producción, y permite determinar el estado del **Debug** mediante la variable de entorno `DJANGO_DEBUG`.
