### PR TITLE
Limpieza de 'private_settings' en gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Archivo de configuración privada del proyecto.
-/reservas/private_settings.py
-
 # Directorio de componentes instalados por Django-Bower.
 /components
 


### PR DESCRIPTION
Se quita del archivo `gitignore` la referencia al **archivo `private_settings.py`**, debido a que dejó de utilizarse.
