### PR TITLE
Modificación de URL para vista de detalle de aula, utilizando su ID

### DIFF
--- a/app_reservas/models/Recurso.py
+++ b/app_reservas/models/Recurso.py
@@ -2,8 +2,6 @@
 
 from django.db import models
 
-from app_reservas.adapters.google_calendar import obtener_eventos
-
 
 class Recurso(models.Model):
     # Atributos

--- a/app_reservas/templatetags/navbar_tags.py
+++ b/app_reservas/templatetags/navbar_tags.py
@@ -1,6 +1,6 @@
 from django import template
 
-from app_reservas.models import Area, Aula, Cuerpo, Nivel
+from app_reservas.models import Area, Cuerpo
 
 register = template.Library()
 

--- a/app_reservas/urls.py
+++ b/app_reservas/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
         name='nivel_detalle'
     ),
     url(
-        r'^cuerpo_(?P<num_cuerpo>[0-9]+)/nivel_(?P<num_nivel>[0-9]+)/aula_(?P<num_aula>[0-9]+)/$',
+        r'^aula/(?P<aula_id>[0-9]+)/$',
         views.aula_detalle,
         name='aula_detalle'
     ),

--- a/app_reservas/views.py
+++ b/app_reservas/views.py
@@ -17,13 +17,9 @@ def area_detalle(request, slug_area):
     )
 
 
-def aula_detalle(request, num_cuerpo, num_nivel, num_aula):
-    # Obtiene el cuerpo.
-    cuerpo = get_object_or_404(Cuerpo, numero=num_cuerpo)
-    # Obtiene el nivel.
-    nivel = get_object_or_404(Nivel, cuerpo=cuerpo, numero=num_nivel)
+def aula_detalle(request, aula_id):
     # Obtiene el aula.
-    aula = get_object_or_404(Aula, nivel=nivel, numero=num_aula)
+    aula = get_object_or_404(Aula, id=aula_id)
     return render(
         request,
         'app_reservas/aula_detalle.html',
@@ -64,6 +60,7 @@ def index(request):
         request,
         'app_reservas/index.html'
     )
+
 
 def solicitud_aula(request):
     return render(

--- a/templates/app_reservas/area_detalle.html
+++ b/templates/app_reservas/area_detalle.html
@@ -68,7 +68,7 @@
                                                data-toggle="tooltip"
                                                data-placement="bottom"
                                                title="Ver"
-                                               href="{% url 'aula_detalle' aula.nivel.cuerpo.numero aula.nivel.numero aula.numero %}">
+                                               href="{% url 'aula_detalle' aula.id %}">
                                                 <span class="glyphicon glyphicon-eye-open"
                                                       aria-hidden="true">
                                                 </span>

--- a/templates/app_reservas/cuerpo_detalle.html
+++ b/templates/app_reservas/cuerpo_detalle.html
@@ -87,7 +87,7 @@
                                                    data-toggle="tooltip"
                                                    data-placement="bottom"
                                                    title="Ver"
-                                                   href="{% url 'aula_detalle' cuerpo.numero nivel.numero aula.numero %}">
+                                                   href="{% url 'aula_detalle' aula.id %}">
                                                     <span class="glyphicon glyphicon-eye-open"
                                                           aria-hidden="true">
                                                     </span>


### PR DESCRIPTION
Se modifica la **composición de la URL** para la vista `aula_detalle`, debido a que ciertas aulas no tenían un número asociado. Por lo tanto, se hace uso del **ID del aula**.
