### PR TITLE
Configuración de settings 'production' por defecto

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "reservas.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "reservas.settings.production")
 
     from django.core.management import execute_from_command_line
 

--- a/reservas/wsgi.py
+++ b/reservas/wsgi.py
@@ -12,7 +12,7 @@ import os
 from django.core.wsgi import get_wsgi_application
 from whitenoise.django import DjangoWhiteNoise
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "reservas.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "reservas.settings.production")
 
 application = get_wsgi_application()
 application = DjangoWhiteNoise(application)


### PR DESCRIPTION
Se indica la configuración **production** por defecto para la variable `DJANGO_SETTINGS_MODULE`.
