### PR TITLE
Especificación de DJANGO_SETTINGS_MODULE antes de la importación de 'whitenoise'

### DIFF
--- a/reservas/wsgi.py
+++ b/reservas/wsgi.py
@@ -10,10 +10,10 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
-from whitenoise.django import DjangoWhiteNoise
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "reservas.settings.production")
 
+from whitenoise.django import DjangoWhiteNoise
+
 application = get_wsgi_application()
 application = DjangoWhiteNoise(application)
-


### PR DESCRIPTION
Se establece el valor de **DJANGO_SETTINGS_MODULE** antes de la importación de **whitenoise**, debido a un error existente en **Django** **[1]** **[2]**.

**[1]** https://stackoverflow.com/questions/31082884/why-is-whitenoise-crashing-in-a-default-django-project-on-heroku
**[2]** https://github.com/evansd/whitenoise/issues/31
