### PR TITLE
Inclusión de badge de 'requires.io' en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # reservas
+
+[![Requirements Status](https://requires.io/github/utn-frm-si/reservas/requirements.svg?branch=master)](https://requires.io/github/utn-frm-si/reservas/requirements/?branch=master)
+
 Gestión de reservas de aulas y laboratorios


### PR DESCRIPTION
Se añade el _badge_ de **[requires.io](https://requires.io/github/utn-frm-si/reservas/requirements/?branch=master)** al `README`.
