### PR TITLE
Espera de inicialización de PostgreSQL, desde el contenedor Django

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,6 @@ RUN apt-get install -y nodejs
 
 # Instala Bower.
 RUN npm install -g bower
+
+# Instala las herramientas de cliente de PostgreSQL.
+RUN apt-get install -y postgresql-client

--- a/run-django.sh
+++ b/run-django.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Función que espera a que PostgreSQL haya sido inicializado.
+function pg_wait {
+  while : ; do
+    pg_isready --host db --user postgres
+    sleep 5
+    if [ $? == 0 ]; then
+      break
+    else
+      sleep 0.1
+    fi
+  done
+}
+
+pg_wait
+
 python manage.py migrate
 python manage.py bower install -- --allow-root
 python manage.py collectstatic --noinput


### PR DESCRIPTION
Debido a que Docker no cuenta con un **manejo nativo de espera a otros contenedores** **[1]**, se implementa la **espera a PostgreSQL, desde el contenedor web de Django** **[2]**.

Además, se instala en el contenedor **web** el paquete `postgresql-client`, para poder hacer uso de la herramienta `pg_isready`, necesaria para la **comprobación del estado de PostgreSQL**.

**[1]** [docker/compose - Issue 374](https://github.com/docker/compose/issues/374)
**[2]** [GovLab/noi2 - PR 25](https://github.com/GovLab/noi2/pull/25)
