### PR TITLE
Corrección en uso de caché para dependencias pip, en Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,12 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN mkdir /code
 WORKDIR /code
 
+# Instala las dependencias del proyecto, mediante pip.
+ADD requirements.txt /code/
+RUN pip install -r requirements.txt
+
 # Añade el contenido del repositorio al directorio '/code'.
 ADD . /code/
-
-# Instala las dependencias del proyecto, mediante pip.
-RUN pip install -r requirements.txt
 
 # Instala NodeJS.
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -


### PR DESCRIPTION
Para aprovechar el **uso de caché por parte de Docker**, en cuanto a la instalación de dependencias mediante `pip`, se efectúa ese paso antes de la copia del directorio actual a `/code`. **[1]**

**[1]** https://stackoverflow.com/a/32029153/5386331
