### PR TITLE
Creación de contenedor Docker de volumen de datos para PostgreSQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,14 @@
+dbdata:
+  image: postgres
+  volumes:
+    - /var/lib/postgresql
+  command: /bin/true
+
 db:
   image: postgres
+  volumes_from:
+    - dbdata
+
 web:
   build: .
   command: /bin/bash run-django.sh


### PR DESCRIPTION
Se añade un nuevo contenedor `dbdata`, para uso como **volumen de datos de PostgreSQL**. **[1]** **[2]**

**[1]** https://docs.docker.com/engine/userguide/dockervolumes/#creating-and-mounting-a-data-volume-container
**[2]** http://www.aidanlister.com/2014/12/how-to-containerize-your-django-application-with-docker-and-fig/
