### PR TITLE
Inicialización automática de contenedores Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,19 @@
 dbdata:
   image: postgres
+  restart: always
   volumes:
     - /var/lib/postgresql
   command: /bin/true
 
 db:
   image: postgres
+  restart: always
   volumes_from:
     - dbdata
 
 web:
   build: .
+  restart: always
   command: /bin/bash run-django.sh
   env_file: ./environment.txt
   volumes:


### PR DESCRIPTION
Se configura la **inicialización automática** de los contenedores Docker, para su funcionamiento continuo, incluso luego de reinicios del equipo anfitrión. **[1]** **[2]**

**[1]** https://docs.docker.com/engine/articles/host_integration/
**[2]** https://docs.docker.com/engine/reference/run/#restart-policies-restart
