### PR TITLE
Configuración de contenedores Docker para RabbitMQ y Celery

### DIFF
--- a/docker-compose.common.yml
+++ b/docker-compose.common.yml
@@ -1,0 +1,4 @@
+web_common:
+  build: .
+  volumes:
+    - .:/code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,31 @@ db:
   volumes_from:
     - dbdata
 
+rabbit:
+  image: rabbitmq
+  restart: always
+
+celery:
+  extends:
+    file: docker-compose.common.yml
+    service: web_common
+  restart: always
+  command: /bin/bash run-celery.sh
+  environment:
+    - C_FORCE_ROOT=true
+    - DATABASE_HOST=postgresql
+    - BROKER_URL=amqp://guest:guest@rabbit//
+  links:
+    - db
+    - rabbit
+
 web:
-  build: .
+  extends:
+    file: docker-compose.common.yml
+    service: web_common
   restart: always
   command: /bin/bash run-django.sh
   env_file: ./environment.txt
-  volumes:
-    - .:/code
   ports:
     - "8000:8000"
   links:

--- a/reservas/celeryapp.py
+++ b/reservas/celeryapp.py
@@ -18,7 +18,7 @@ app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 app.conf.CELERYBEAT_SCHEDULE = {
     'obtener_eventos_recursos': {
-        'task': 'obtencion_eventos_recursos',
+        'task': 'obtener_eventos_recursos',
         'schedule': timedelta(hours=1)
     },
 }

--- a/run-celery.sh
+++ b/run-celery.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Función que espera a que PostgreSQL haya sido inicializado.
+function pg_wait {
+  while : ; do
+    pg_isready --host db --user postgres
+    if [ $? == 0 ]; then
+      break
+    else
+      sleep 1
+    fi
+  done
+}
+
+# Función que espera a que RabbitMQ haya sido inicializado.
+# Actualmente, sólo espera 3 segundos, sin efectuar verificaciones.
+function rabbitmq_wait {
+  sleep 3
+}
+
+pg_wait
+rabbitmq_wait
+
+celery worker -A reservas -B -l info -b "${BROKER_URL}"


### PR DESCRIPTION
Se configuran, mediante `docker-compose`, los **contenedores de RabbitMQ y Celery**. Además, debido a que tanto el contenedor de Celery como el de Django hacen uso de la misma imagen, se crea el archivo `docker-compose.common.yml`, para que **extiendan de una configuración común**, y así **crear la imagen una única vez**.

También se corrige un error sintáctico, que **indicaba en forma incorrecta la tarea a ejecutar por Celery Beat**.
