### PR TITLE
Adición de archivo de entorno a contenedor de Celery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ celery:
     service: web_common
   restart: always
   command: /bin/bash run-celery.sh
+  env_file: ./environment.txt
   environment:
     - C_FORCE_ROOT=true
     - DATABASE_HOST=postgresql


### PR DESCRIPTION
Se agrega al contenedor de Celery, el archivo con la **especificación de las variables de entorno**. Esto es necesario ya que el archivo especifica el **token a utilizar para la comunicación con Google Calendar**, que  es requerido para las tareas actuales de Celery.
