### PR TITLE
Obtención de eventos del recurso, por intervalo de fechas

### DIFF
--- a/app_reservas/urls.py
+++ b/app_reservas/urls.py
@@ -29,6 +29,11 @@ urlpatterns = [
         name='area_detalle'
     ),
     url(
+        r'^aula/(?P<aula_id>[0-9]+)/eventos/$',
+        views.aula_eventos_json,
+        name='aula_eventos_json'
+    ),
+    url(
         r'^solicitud/aula/$',
         views.solicitud_aula,
         name='solicitud_aula'

--- a/templates/app_reservas/area_detalle.html
+++ b/templates/app_reservas/area_detalle.html
@@ -130,7 +130,7 @@
         ],
         eventSources: [
             {% for aula in area.get_aulas %}
-                '/media/app_reservas/eventos_aulas/{{ aula.id }}.json',
+                '{% url "aula_eventos_json" aula.id %}',
             {% endfor %}
         ],
         minTime: last_hour,

--- a/templates/app_reservas/aula_detalle.html
+++ b/templates/app_reservas/aula_detalle.html
@@ -32,7 +32,7 @@
         schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
         lang: 'es',
         eventSources: [
-            '/media/app_reservas/eventos_aulas/{{ aula.id }}.json'
+            '{% url "aula_eventos_json" aula.id %}'
         ],
     });
 </script>

--- a/templates/app_reservas/cuerpo_detalle.html
+++ b/templates/app_reservas/cuerpo_detalle.html
@@ -167,7 +167,7 @@
         eventSources: [
             {% for nivel in cuerpo.get_niveles %}
                 {% for aula in nivel.get_aulas %}
-                    '/media/app_reservas/eventos_aulas/{{ aula.id }}.json',
+                    '{% url "aula_eventos_json" aula.id %}',
                 {% endfor %}
             {% endfor %}
         ],

--- a/templates/app_reservas/nivel_detalle.html
+++ b/templates/app_reservas/nivel_detalle.html
@@ -131,7 +131,7 @@
         ],
         eventSources: [
             {% for aula in nivel.get_aulas %}
-                '/media/app_reservas/eventos_aulas/{{ aula.id }}.json',
+                '{% url "aula_eventos_json" aula.id %}',
             {% endfor %}
         ],
         minTime: last_hour,


### PR DESCRIPTION
Se implementa una nueva **vista**, para la obtención de eventos de un recurso, de acuerdo a un **intervalo de fechas**. Esto **reduce drásticamente la cantidad de datos a transmitir**, ya que hasta el momento se transferían _todos_ los eventos de cada recurso, cada vez que se navegaba a través de las fechas en **FullCalendar**. Actualmente, sólo se transfieren los eventos acordes al intervalo visualizado.

Se aprovechan los parámetros que utiliza por defecto **FullCalendar** (`start` y `end`), para comunicar el intervalo de fechas que está mostrando actualmente. **[1]**

**[1]** http://fullcalendar.io/docs/event_data/events_json_feed/
