### PR TITLE
Mejora en el armado de eventos en formato JSON

### DIFF
--- a/app_reservas/models/Aula.py
+++ b/app_reservas/models/Aula.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 
+import json
+
 from django.db import models
 
 from app_reservas.adapters.google_calendar import obtener_eventos
@@ -40,10 +42,12 @@ class Aula(Recurso):
                 primera_iteracion = False
             else:
                 eventos_json += ','
-            evento_str = '{"title": "' + evento['titulo'] + '", ' + \
-                         '"start": "' + evento['inicio_str'] + '", ' + \
-                         '"end": "' + evento['fin_str'] + '", ' + \
-                         '"resourceId": "' + str(self.id) + '"}'
+            evento_str = json.dumps({
+                'title': evento['titulo'],
+                'start': evento['inicio_str'],
+                'end': evento['fin_str'],
+                'resourceId': str(self.id)
+            })
             eventos_json += evento_str
         eventos_json += ']'
         return eventos_json


### PR DESCRIPTION
Se actualiza el **armado de eventos en formato JSON**, para hacer uso de `json.dumps`. De esta manera, se **escapan correctamente los caracteres que producían conflicto**, como las comillas dobles (`"`) dentro del título del evento.
