### PR TITLE
Corrección en comprobación de aulas de un nivel

### DIFF
--- a/templates/app_reservas/nivel_detalle.html
+++ b/templates/app_reservas/nivel_detalle.html
@@ -54,8 +54,8 @@
                             </tr>
                             </thead>
                             <tbody>
-                            {% if area.get_aulas %}
-                                {% for aula in area.get_aulas %}
+                            {% if nivel.get_aulas %}
+                                {% for aula in nivel.get_aulas %}
                                     <tr>
                                         <td>
                                             {{ aula }}


### PR DESCRIPTION
Se corrige el error presente en el **detalle de un nivel**, que no comprobaba correctamente si el nivel tenía aulas relacionadas.
