### PR TITLE
Especificación de minTime para FullCalendar

### DIFF
--- a/templates/app_reservas/area_detalle.html
+++ b/templates/app_reservas/area_detalle.html
@@ -133,7 +133,7 @@
                 '{% url "aula_eventos_json" aula.id %}',
             {% endfor %}
         ],
-        minTime: last_hour,
+        minTime: '07:00:00',
     });
 </script>
 {% endblock %}

--- a/templates/app_reservas/aula_detalle.html
+++ b/templates/app_reservas/aula_detalle.html
@@ -34,6 +34,7 @@
         eventSources: [
             '{% url "aula_eventos_json" aula.id %}'
         ],
+        minTime: '07:00:00',
     });
 </script>
 {% endblock %}

--- a/templates/app_reservas/cuerpo_detalle.html
+++ b/templates/app_reservas/cuerpo_detalle.html
@@ -171,7 +171,7 @@
                 {% endfor %}
             {% endfor %}
         ],
-        minTime: last_hour,
+        minTime: '07:00:00',
     });
 </script>
 {% endblock %}

--- a/templates/app_reservas/nivel_detalle.html
+++ b/templates/app_reservas/nivel_detalle.html
@@ -134,7 +134,7 @@
                 '{% url "aula_eventos_json" aula.id %}',
             {% endfor %}
         ],
-        minTime: last_hour,
+        minTime: '07:00:00',
     });
 </script>
 {% endblock %}


### PR DESCRIPTION
Se especifica como `minTime` (hora inicial a mostrar en el calendario **[1]**) las 07:00 AM, para todos los calendarios existentes.

**[1]** http://fullcalendar.io/docs/agenda/minTime/
