### PR TITLE
Especificación de cabecera de la columna de recursos, en calendario

### DIFF
--- a/templates/app_reservas/area_detalle.html
+++ b/templates/app_reservas/area_detalle.html
@@ -120,6 +120,7 @@
         defaultView: 'timelineDay',
         schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
         lang: 'es',
+        resourceLabelText: 'Aula',
         resources: [
             {% for aula in area.get_aulas %}
                 {

--- a/templates/app_reservas/nivel_detalle.html
+++ b/templates/app_reservas/nivel_detalle.html
@@ -121,6 +121,7 @@
         defaultView: 'timelineDay',
         schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
         lang: 'es',
+        resourceLabelText: 'Aula',
         resources: [
             {% for aula in nivel.get_aulas %}
                 {


### PR DESCRIPTION
Se cambia la cabecera de la **columna de recursos** en FullCalendar, de **Resources** a **Aula**.
