### PR TITLE
Creación de señal 'post_save' para obtener eventos de nuevo recurso

### DIFF
--- a/app_reservas/apps.py
+++ b/app_reservas/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class ReservasConfig(AppConfig):
+    name = 'app_reservas'
+    verbose_name = 'Reservas'
+
+    def ready(self):
+        import app_reservas.signals.recurso

--- a/app_reservas/signals/recurso.py
+++ b/app_reservas/signals/recurso.py
@@ -1,0 +1,17 @@
+from django.db.models.signals import post_save
+
+from app_reservas.models import Recurso
+from app_reservas.tasks import obtener_eventos_recurso_especifico
+
+
+def obtener_eventos(sender, instance, created, **kwargs):
+    if created:
+        obtener_eventos_recurso_especifico.delay(instance)
+
+# Conecta la clase 'Recurso' y todas sus subclases a la señal 'post_save'.
+# Esto se realiza ya que, al conectar sólo la clase 'Recurso', la señal no es
+# enviada cuando se crea una instancia de alguna de sus subclases, debido a que
+# no es propagada.
+post_save.connect(obtener_eventos, Recurso)
+for subclass in Recurso.__subclasses__():
+    post_save.connect(obtener_eventos, subclass)

--- a/app_reservas/tasks.py
+++ b/app_reservas/tasks.py
@@ -20,7 +20,7 @@ def obtener_eventos_recursos():
 
 
 @shared_task(name='obtener_eventos_recurso_especifico')
-def obtener_eventos_recurso_especifico(recurso, ruta_archivos):
+def obtener_eventos_recurso_especifico(recurso, ruta_archivos='media/app_reservas/eventos_recursos/'):
     if isinstance(recurso, Recurso):
         # Arma el nombre del archivo.
         nombre_archivo = str(recurso.id) + '.json'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,10 @@ web:
   restart: always
   command: /bin/bash run-django.sh
   env_file: ./environment.txt
+  environment:
+    - BROKER_URL=amqp://guest:guest@rabbit//
   ports:
     - "8000:8000"
   links:
     - db
+    - rabbit

--- a/reservas/settings/base.py
+++ b/reservas/settings/base.py
@@ -40,7 +40,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'djangobower',
     'app_facturacion',
-    'app_reservas',
+    'app_reservas.apps.ReservasConfig',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -132,3 +132,5 @@ BOWER_INSTALLED_APPS = (
 # Token de Google Calendar, utilizado para consultar la información de eventos
 # de los calendarios de Google Calendar.
 GOOGLE_CALENDAR_TOKEN = os.environ.get('GOOGLE_CALENDAR_TOKEN', '')
+
+BROKER_URL = os.environ.get('BROKER_URL', 'amqp://guest:guest@rabbit//')


### PR DESCRIPTION
Se implementa una **señal `post_save`** (**[1]** **[2]**) a la clase **Recurso** y a sus **subclases** **[3]**. Esto permite obtener los **eventos del recurso**, cuando el mismo es creado, en vez de tener que esperar a la próxima ejecución de _Celery Beat_.

Para esto, fue necesario además **cargar las señales** en la configuración de la aplicación **[4]** **[5]**. Además, debido a que la tarea es generada por el contenedor de Django, se enlazó el mismo al **contenedor de RabbitMQ**.

**[1]** https://docs.djangoproject.com/en/dev/topics/signals/
**[2]** https://docs.djangoproject.com/en/dev/ref/signals/#django.db.models.signals.post_save
**[3]** https://stackoverflow.com/a/24624838/5386331
**[4]** https://stackoverflow.com/questions/2719038/where-should-signal-handlers-live-in-a-django-project
**[5]** https://docs.djangoproject.com/en/dev/ref/applications/#django.apps.AppConfig.ready
