### PR TITLE
Obtención de eventos de Google Calendar, con paginación

### DIFF
--- a/app_reservas/adapters/google_calendar.py
+++ b/app_reservas/adapters/google_calendar.py
@@ -44,14 +44,22 @@ def generar_lista_eventos(eventos):
 def obtener_eventos(calendar_id):
     service = crear_servicio()
 
-    events_result = service.events().list(
-        calendarId=calendar_id,
-        maxResults=2500,
-        singleEvents=True,
-        orderBy='startTime'
-    ).execute()
+    eventos = []
+    page_token = None
+    while True:
+        events_result = service.events().list(
+            calendarId=calendar_id,
+            maxResults=2500,
+            singleEvents=True,
+            pageToken=page_token,
+            orderBy='startTime'
+        ).execute()
 
-    eventos = events_result.get('items', [])
+        eventos.extend(events_result.get('items', []))
+        page_token = events_result.get('nextPageToken')
+        if not page_token:
+            break
+
     return generar_lista_eventos(eventos)
 
 


### PR DESCRIPTION
Las solicitudes a la API de Google Calendar permiten un **retorno máximo de 2500 eventos**. Por lo tanto, en caso de que este límite sea superado, se implementa la **solicitud del resto de páginas** de resultados, según indica la documentación de la API **[1]**. De esta manera, se evita el no recibir la totalidad de los eventos de un calendario.

**[1]** https://developers.google.com/google-apps/calendar/v3/reference/events/list
