### PR TITLE
Obtención de eventos únicamente del año actual y siguiente

### DIFF
--- a/app_reservas/adapters/google_calendar.py
+++ b/app_reservas/adapters/google_calendar.py
@@ -41,8 +41,23 @@ def generar_lista_eventos(eventos):
     return lista_eventos
 
 
-def obtener_eventos(calendar_id):
+def obtener_eventos(calendar_id, limite_anio_siguiente=True):
     service = crear_servicio()
+
+    primer_dia_anio_actual = None
+    primer_dia_anio_subsiguiente = None
+    if limite_anio_siguiente:
+        # Obtiene únicamente los eventos del año actual y el siguiente.
+        primer_dia_anio_actual = datetime(
+            datetime.today().year,
+            1,
+            1,
+        ).isoformat('T') + 'Z'
+        primer_dia_anio_subsiguiente = datetime(
+            datetime.today().year + 2,
+            1,
+            1,
+        ).isoformat('T') + 'Z'
 
     eventos = []
     page_token = None
@@ -51,6 +66,8 @@ def obtener_eventos(calendar_id):
             calendarId=calendar_id,
             maxResults=2500,
             singleEvents=True,
+            timeMin=primer_dia_anio_actual,
+            timeMax=primer_dia_anio_subsiguiente,
             pageToken=page_token,
             orderBy='startTime'
         ).execute()

--- a/templates/app_reservas/base_calendario.html
+++ b/templates/app_reservas/base_calendario.html
@@ -51,7 +51,7 @@
                     // Comprueba que el datepicker ya haya sido cargado. Sino, retorna.
                     if (! datepicker.data('datepicker')) {
                         return;
-                    };
+                    }
                     // Obtiene las fechas establecidas, en el calendario y en el datepicker.
                     var fechaFullcalendar = new Date(view.intervalStart);
                     var fechaDatepicker = new Date(datepicker.datepicker('getDate'));
@@ -63,7 +63,7 @@
                     // correctamente el estado actual del calendario.
                     if (! momentoFullcalendar.isSame(momentoDatepicker, 'day')) {
                         datepicker.datepicker('setUTCDate', momentoFullcalendar.toDate());
-                    };
+                    }
                 },
                 loading: function(isLoading, view) {
                     if (isLoading) {
@@ -84,12 +84,21 @@
 
     <script>
         $(document).ready(function() {
+            var primer_dia_anio_actual = new Date(new Date().getFullYear(),
+                                                  0,
+                                                  1);
+            var ultimo_dia_anio_siguiente = new Date(new Date().getFullYear() + 1,
+                                                     11,
+                                                     31);
+
             $('.fc-datepickerButton-button').datepicker({
                 format: 'dd/mm/yyyy',
                 language: 'es',
                 daysOfWeekDisabled: '0',
                 autoclose: true,
-                todayHighlight: true
+                todayHighlight: true,
+                startDate: primer_dia_anio_actual,
+                endDate: ultimo_dia_anio_siguiente,
             })
                 .on('changeDate', function(e) {
                     $('#calendar').fullCalendar('gotoDate', e.date);


### PR DESCRIPTION
Se implementa la **solicitud de eventos** de Google Calendar, sólo para el **año en curso y siguiente**. De esta manera, se limita la cantidad de resultados obtenidos, filtrando aquellos eventos históricos y de años posteriores, que no son de interés, **priorizando así los eventos del año actual y del año siguiente**.
