### PR TITLE
Eliminación de URL de broken el script de inicialización de Celery

### DIFF
--- a/run-celery.sh
+++ b/run-celery.sh
@@ -21,4 +21,4 @@ function rabbitmq_wait {
 pg_wait
 rabbitmq_wait
 
-celery worker -A reservas -B -l info -b "${BROKER_URL}"
+celery worker -A reservas -B -l info


### PR DESCRIPTION
Debido a la especificación de la variable `BROKER_URL` en #73, ya no es necesario incluir la dirección URL del broker en el script de inicialización de Celery.
