### PR TITLE
Ordenamiento de tags del navbar y de aulas

### DIFF
--- a/app_reservas/models/Area.py
+++ b/app_reservas/models/Area.py
@@ -13,7 +13,7 @@ class Area(models.Model):
         return self.nombre
 
     def get_aulas(self):
-        return self.aula_set.order_by('numero')
+        return self.aula_set.order_by('numero', 'nombre')
 
     # Información de la clase
     class Meta:

--- a/app_reservas/models/Nivel.py
+++ b/app_reservas/models/Nivel.py
@@ -17,7 +17,7 @@ class Nivel(models.Model):
         return 'Nivel %s' % self.numero
 
     def get_aulas(self):
-        return self.aula_set.order_by('numero')
+        return self.aula_set.order_by('numero', 'nombre')
 
     # Información de la clase
     class Meta:

--- a/app_reservas/templatetags/navbar_tags.py
+++ b/app_reservas/templatetags/navbar_tags.py
@@ -8,7 +8,7 @@ register = template.Library()
 @register.inclusion_tag('app_reservas/navbar.html')
 def obtener_informacion_navbar():
     context = {
-        'lista_cuerpos': Cuerpo.objects.all(),
-        'lista_areas': Area.objects.all()
+        'lista_cuerpos': Cuerpo.objects.order_by('numero'),
+        'lista_areas': Area.objects.order_by('nombre'),
     }
     return context


### PR DESCRIPTION
Se ordenan por **número** los elementos _cuerpos_ y _áreas_ del navbar, y se especifica que las aulas se ordenen por nombre luego de ser ordenadas por número.
