### PR TITLE
Cambio de apartado 'Áreas' por 'Aulas' en navbar

### DIFF
--- a/templates/app_reservas/navbar.html
+++ b/templates/app_reservas/navbar.html
@@ -38,7 +38,7 @@
                        role="button"
                        aria-haspopup="true"
                        aria-expanded="false">
-                        Áreas <span class="caret"></span>
+                        Aulas <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
                         {% for area in lista_areas %}


### PR DESCRIPTION
Se cambia el título del elemento **Áreas** del _navbar_, por **Aulas**.
