### PR TITLE
Modificación del nombre corto de laboratorio informático

### DIFF
--- a/app_reservas/models/LaboratorioInformatico.py
+++ b/app_reservas/models/LaboratorioInformatico.py
@@ -18,7 +18,7 @@ class LaboratorioInformatico(Recurso):
         return 'Laboratorio informático: %s' % self.nombre
 
     def get_nombre_corto(self):
-        return self.alias
+        return '%s (%s)' % (self.nombre, self.alias)
 
     # Información de la clase
     class Meta:

--- a/templates/app_reservas/laboratorio_informatico_listado.html
+++ b/templates/app_reservas/laboratorio_informatico_listado.html
@@ -57,7 +57,7 @@
                                 {% for laboratorio in laboratorios %}
                                     <tr>
                                         <td>
-                                            {{ laboratorio }}
+                                            {{ laboratorio.get_nombre_corto }}
                                         </td>
                                         <td class="text-center">
                                             {{ laboratorio.capacidad }}


### PR DESCRIPTION
Se modifica el **nombre corto** de los laboratorios informáticos, para detallar tanto su **nombre** como su **alias**.
