### PR TITLE
Implementación de cambio de nombre automático en archivo de ubicación del aula

### DIFF
--- a/app_reservas/migrations/0008_directorio_archivo_ubicacion_aula.py
+++ b/app_reservas/migrations/0008_directorio_archivo_ubicacion_aula.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import app_reservas.models.Aula
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('app_reservas', '0007_clase_laboratorio_informatico'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='aula',
+            name='archivo_ubicacion',
+            field=models.FileField(blank=True, upload_to=app_reservas.models.Aula.establecer_destino_archivo_ubicacion),
+        ),
+    ]

--- a/app_reservas/models/Aula.py
+++ b/app_reservas/models/Aula.py
@@ -1,8 +1,19 @@
 # coding=utf-8
 
+import os
+
 from django.db import models
+from django.template.defaultfilters import slugify
 
 from .Recurso import Recurso
+
+
+def establecer_destino_archivo_ubicacion(instance, filename):
+    # Almacena el archivo en: 'app_reservas/ubicaciones/aulas/<nombre_completo_del_aula>.<extension>'
+    ruta_archivos_ubicacion = 'app_reservas/ubicaciones/aulas/'
+    extension_archivo = filename.split('.')[-1] if '.' in filename else ''
+    nombre_archivo = '%s.%s' % (slugify(str(instance)), extension_archivo)
+    return os.path.join(ruta_archivos_ubicacion, nombre_archivo)
 
 
 class Aula(Recurso):
@@ -10,7 +21,7 @@ class Aula(Recurso):
     numero = models.PositiveSmallIntegerField()
     nombre = models.CharField(max_length=50, blank=True)
     capacidad = models.PositiveSmallIntegerField()
-    archivo_ubicacion = models.FileField(upload_to='ubicacion_aulas', blank=True)
+    archivo_ubicacion = models.FileField(upload_to=establecer_destino_archivo_ubicacion, blank=True)
     # Relaciones
     areas = models.ManyToManyField('Area')
     nivel = models.ForeignKey('Nivel')
@@ -26,6 +37,11 @@ class Aula(Recurso):
         else:
             nombre_corto = self.nombre
         return nombre_corto
+
+    # FIXME: Método necesario para que la migración funcione correctamente.
+    @staticmethod
+    def establecer_destino_archivo_ubicacion(instance, filename):
+        return establecer_destino_archivo_ubicacion(instance, filename)
 
     # Información de la clase
     class Meta:

--- a/templates/app_reservas/area_detalle.html
+++ b/templates/app_reservas/area_detalle.html
@@ -79,7 +79,7 @@
                                                    data-toggle="tooltip"
                                                    data-placement="bottom"
                                                    title="Ubicación"
-                                                   href="/{{ aula.archivo_ubicacion.url }}">
+                                                   href="{{ aula.archivo_ubicacion.url }}">
                                                     <span class="glyphicon glyphicon-map-marker"
                                                           aria-hidden="true">
                                                     </span>

--- a/templates/app_reservas/cuerpo_detalle.html
+++ b/templates/app_reservas/cuerpo_detalle.html
@@ -98,7 +98,7 @@
                                                        data-toggle="tooltip"
                                                        data-placement="bottom"
                                                        title="Ubicación"
-                                                       href="/{{ aula.archivo_ubicacion.url }}">
+                                                       href="{{ aula.archivo_ubicacion.url }}">
                                                         <span class="glyphicon glyphicon-map-marker"
                                                               aria-hidden="true">
                                                         </span>

--- a/templates/app_reservas/nivel_detalle.html
+++ b/templates/app_reservas/nivel_detalle.html
@@ -80,7 +80,7 @@
                                                    data-toggle="tooltip"
                                                    data-placement="bottom"
                                                    title="Ubicación"
-                                                   href="/{{ aula.archivo_ubicacion.url }}">
+                                                   href="{{ aula.archivo_ubicacion.url }}">
                                                     <span class="glyphicon glyphicon-map-marker"
                                                           aria-hidden="true">
                                                     </span>


### PR DESCRIPTION
Se hace uso de un **métodp personalizado** en **FileField** **[1]** para generar la ruta donde se almacena el **archivo de ubicación del aula**. De esta manera, al subir un archivo, el mismo se renombra para coincidir con el **nombre completo del aula**.

Debido a la configuración del archivo `app_reservas/models/__init__py`, fue necesario crear un método estático en **Aula**, para que no fallara la línea `app_reservas.models.Aula.establecer_destino_archivo_ubicacion` de la nueva migración.

**[1]**https://docs.djangoproject.com/en/1.9/ref/models/fields/#filefield
