### PR TITLE
Consideración de capacidad nula de un recurso

### DIFF
--- a/templates/app_reservas/area_detalle.html
+++ b/templates/app_reservas/area_detalle.html
@@ -60,7 +60,11 @@
                                             {{ aula }}
                                         </td>
                                         <td class="text-center">
-                                            {{ aula.capacidad }}
+                                            {% if aula.capacidad > 0 %}
+                                                {{ aula.capacidad }}
+                                            {% else %}
+                                                &#8212;
+                                            {% endif %}
                                         </td>
                                         <td class="text-center">
                                             <a role="button"

--- a/templates/app_reservas/cuerpo_detalle.html
+++ b/templates/app_reservas/cuerpo_detalle.html
@@ -71,13 +71,17 @@
                                                 {{ aula.get_nombre_corto }}
                                             </td>
                                             <td class="text-center">
-                                                {{ aula.capacidad }}
+                                                {% if aula.capacidad > 0 %}
+                                                    {{ aula.capacidad }}
+                                                {% else %}
+                                                    &#8212;
+                                                {% endif %}
                                             </td>
                                             <td class="text-center">
                                                 {% for area in aula.areas.all %}
                                                     {{ area }}
                                                     {% if not forloop.last %}
-                                                        ,
+                                                        &#8212;
                                                     {% endif %}
                                                 {% endfor %}
                                             </td>
@@ -140,7 +144,11 @@
                                                 {{ laboratorio.get_nombre_corto }}
                                             </td>
                                             <td class="text-center">
-                                                {{ laboratorio.capacidad }}
+                                                {% if laboratorio.capacidad > 0 %}
+                                                    {{ laboratorio.capacidad }}
+                                                {% else %}
+                                                    &#8212;
+                                                {% endif %}
                                             </td>
                                             <td class="text-center">
                                                 <a role="button"

--- a/templates/app_reservas/laboratorio_informatico_listado.html
+++ b/templates/app_reservas/laboratorio_informatico_listado.html
@@ -60,7 +60,11 @@
                                             {{ laboratorio.get_nombre_corto }}
                                         </td>
                                         <td class="text-center">
-                                            {{ laboratorio.capacidad }}
+                                            {% if laboratorio.capacidad > 0 %}
+                                                {{ laboratorio.capacidad }}
+                                            {% else %}
+                                                &#8212;
+                                            {% endif %}
                                         </td>
                                         <td class="text-center">
                                             <a role="button"

--- a/templates/app_reservas/nivel_detalle.html
+++ b/templates/app_reservas/nivel_detalle.html
@@ -61,7 +61,11 @@
                                             {{ aula }}
                                         </td>
                                         <td class="text-center">
-                                            {{ aula.capacidad }}
+                                            {% if aula.capacidad > 0 %}
+                                                {{ aula.capacidad }}
+                                            {% else %}
+                                                &#8212;
+                                            {% endif %}
                                         </td>
                                         <td class="text-center">
                                             <a role="button"
@@ -123,6 +127,9 @@
                                     Laboratorio informático
                                 </th>
                                 <th class="text-center">
+                                    Capacidad
+                                </th>
+                                <th class="text-center">
                                     Acciones
                                 </th>
                             </tr>
@@ -132,6 +139,13 @@
                                     <tr>
                                         <td>
                                             {{ laboratorio.get_nombre_corto }}
+                                        </td>
+                                        <td class="text-center">
+                                            {% if laboratorio.capacidad > 0 %}
+                                                {{ laboratorio.capacidad }}
+                                            {% else %}
+                                                &#8212;
+                                            {% endif %}
                                         </td>
                                         <td class="text-center">
                                             <a role="button"


### PR DESCRIPTION
En los casos en los que la **capacidad de un recurso es nula**, en vez de indicar la misma como _"0"_, se muestra un guión largo.
