### PR TITLE
Actualización de Django a 1.8.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8.5
+Django==1.8.8
 amqp==1.4.8
 anyjson==0.3.3
 billiard==3.3.0.22


### PR DESCRIPTION
Se actualiza **Django** a la versión **1.8.8**. **[1]**

**[1]** https://docs.djangoproject.com/en/dev/releases/1.8.8/
