### PR TITLE
Actualización de imagen base de Dockerfile, a Python 3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4
+FROM python:3.5
 
 # Configura el modo no interactivo.
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Se actualiza la **imagen base** utilizada para los contenedores Docker de **Django** y **Celery**, para hacer uso de la versión **3.5 de Python**. Esto se debe a que, desde la versión `1.8.6` de Django, se añadió soporte para dicha versión de Python. **[1]**

**[1]** https://docs.djangoproject.com/en/dev/releases/1.8.6/
