### PR TITLE
Especificación de altura automática de los calendarios

### DIFF
--- a/templates/app_reservas/area_detalle.html
+++ b/templates/app_reservas/area_detalle.html
@@ -124,6 +124,7 @@
         defaultView: 'timelineDay',
         schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
         lang: 'es',
+        contentHeight: 'auto',
         resourceLabelText: 'Aula',
         resources: [
             {% for aula in area.get_aulas %}

--- a/templates/app_reservas/aula_detalle.html
+++ b/templates/app_reservas/aula_detalle.html
@@ -31,6 +31,7 @@
         defaultView: 'agendaWeek',
         schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
         lang: 'es',
+        contentHeight: 'auto',
         eventSources: [
             '{% url "recurso_eventos_json" aula.id %}'
         ],

--- a/templates/app_reservas/cuerpo_detalle.html
+++ b/templates/app_reservas/cuerpo_detalle.html
@@ -194,6 +194,7 @@
         defaultView: 'timelineDay',
         schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
         lang: 'es',
+        contentHeight: 'auto',
         resourceColumns: [
             {
                 group: true,

--- a/templates/app_reservas/laboratorio_informatico_detalle.html
+++ b/templates/app_reservas/laboratorio_informatico_detalle.html
@@ -31,6 +31,7 @@
         defaultView: 'agendaWeek',
         schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
         lang: 'es',
+        contentHeight: 'auto',
         eventSources: [
             '{% url "recurso_eventos_json" laboratorio.id %}'
         ],

--- a/templates/app_reservas/laboratorio_informatico_listado.html
+++ b/templates/app_reservas/laboratorio_informatico_listado.html
@@ -112,6 +112,7 @@
             defaultView: 'timelineDay',
             schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
             lang: 'es',
+            contentHeight: 'auto',
             resourceLabelText: 'Laboratorio informático',
             resources: [
                 {% for laboratorio in laboratorios %}

--- a/templates/app_reservas/nivel_detalle.html
+++ b/templates/app_reservas/nivel_detalle.html
@@ -189,6 +189,7 @@
         defaultView: 'timelineDay',
         schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
         lang: 'es',
+        contentHeight: 'auto',
         resourceLabelText: 'Aula',
         resources: [
             {% for aula in nivel.get_aulas %}


### PR DESCRIPTION
Se configuran todos los calendarios, para que su **altura** quede determinada **automáticamente según su contenido** **[1]**. Esto permite que no se muestre más grande de lo necesario, ni que muestre barras de _scroll_ cuando el calendario presenta gran cantidad de recursos.

**[1]** http://fullcalendar.io/docs/display/contentHeight/
