### PR TITLE
Configuración de aplicación de reservas como URL por defecto

### DIFF
--- a/reservas/urls.py
+++ b/reservas/urls.py
@@ -24,10 +24,6 @@ urlpatterns = [
             include('app_facturacion.urls')
         ),
         url(
-            r'^reservas/',
-            include('app_reservas.urls')
-        ),
-        url(
             r'^admin/',
             include(admin.site.urls)
         ),
@@ -44,6 +40,10 @@ urlpatterns = [
             {
                 'document_root': settings.STATIC_ROOT,
             }
+        ),
+        url(
+            r'',
+            include('app_reservas.urls')
         ),
     ])),
 ]


### PR DESCRIPTION
Se modifica la **URL** de la **aplicación _reservas_**, para ser accedida en forma directa, sin necesidad de especificar un prefijo en la URL (salvo el prefijo del proyecto Django).
