### PR TITLE
Cambio de periodicidad de obtención de eventos mediante 'Celery Beat'

### DIFF
--- a/reservas/celeryapp.py
+++ b/reservas/celeryapp.py
@@ -19,7 +19,7 @@ app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 app.conf.CELERYBEAT_SCHEDULE = {
     'obtener_eventos_recursos': {
         'task': 'obtener_eventos_recursos',
-        'schedule': timedelta(hours=1)
+        'schedule': timedelta(minutes=15)
     },
 }
 


### PR DESCRIPTION
Se modifica la **periodicidad de la tarea de obtención de eventos para los recursos**, ejecutada por _Celery Beat_, pasando de una periodicidad de **1 hora**, a una de **15 minutos**.
