### PR TITLE
Utilización de Gunicorn en el contenedor Django

### DIFF
--- a/run-django.sh
+++ b/run-django.sh
@@ -19,4 +19,4 @@ python manage.py migrate
 python manage.py bower install -- --allow-root
 python manage.py collectstatic --noinput
 
-python manage.py runserver 0.0.0.0:8000
+gunicorn reservas.wsgi:application -b :8000


### PR DESCRIPTION
Se cambia la ejecución de `runserver` por **gunicorn**, para su correcto funcionamiento en producción.
