### PR TITLE
Creación de plantilla base para páginas con calendario

### DIFF
--- a/templates/app_reservas/area_detalle.html
+++ b/templates/app_reservas/area_detalle.html
@@ -1,24 +1,13 @@
-{% extends 'app_reservas/base.html' %}
+{% extends 'app_reservas/base_calendario.html' %}
 {% load static %}
-
-{% block static_css %}
-    <!--Fullcalendar-Scheduler-->
-    <link rel='stylesheet' href='{% static 'fullcalendar/dist/fullcalendar.min.css' %}' />
-    <link rel='stylesheet' href='{% static 'fullcalendar-scheduler/dist/scheduler.min.css' %}' />
-    <script src='{% static 'moment/min/moment.min.js' %}'></script>
-    <script src='{% static 'jquery/dist/jquery.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/fullcalendar.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/lang/es.js' %}'></script>
-    <script src='{% static 'fullcalendar-scheduler/dist/scheduler.min.js' %}'></script>
-{% endblock %}
 
 {% block title %}
     Área: {{ area }}
 {% endblock %}
 
-{% block contenido %}
 
-<h1 style="text-align: center;">{{ area }}</h1>
+{% block contenido %}
+    <h1 style="text-align: center;">{{ area }}</h1>
 
     <br />
     <br />
@@ -105,46 +94,44 @@
         </div>
     </div>
 
-<br />
-<br />
+    <br />
+    <br />
 
-<div id="calendar"></div>
+    <div id="calendar"></div>
+{% endblock contenido %}
+
+
+{% block scripts %}
+    {{ block.super }}
 
     <script>
         $(function () {
             $('[data-toggle="tooltip"]').tooltip()
         });
     </script>
+{% endblock %}
 
-<script>
-    var current_date = new Date();
-    var last_hour = (current_date.getHours() - 1) + ":00:00";
 
-    $('#calendar').fullCalendar({
-        defaultView: 'timelineDay',
-        schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
-        lang: 'es',
-        contentHeight: 'auto',
-        resourceLabelText: 'Aula',
-        resources: [
-            {% for aula in area.get_aulas %}
-                {
-                    id: '{{ aula.id }}',
-                    title: '{{ aula }}',
-                },
-            {% endfor %}
-        ],
-        eventSources: [
-            {% for aula in area.get_aulas %}
-                {
-                    url: '{% url "recurso_eventos_json" aula.id %}',
-                    {% if aula.calendar_color %}
-                        color: '{{ aula.calendar_color }}',
-                    {% endif %}
-                },
-            {% endfor %}
-        ],
-        minTime: '07:00:00',
-    });
-</script>
+{% block fullcalendar_resources %}
+    resourceLabelText: 'Aula',
+    resources: [
+        {% for aula in area.get_aulas %}
+            {
+                id: '{{ aula.id }}',
+                title: '{{ aula }}',
+            },
+        {% endfor %}
+    ],
+{% endblock fullcalendar_resources %}
+
+
+{% block fullcalendar_eventSources %}
+    {% for aula in area.get_aulas %}
+        {
+            url: '{% url "recurso_eventos_json" aula.id %}',
+            {% if aula.calendar_color %}
+                color: '{{ aula.calendar_color }}',
+            {% endif %}
+        },
+    {% endfor %}
 {% endblock %}

--- a/templates/app_reservas/aula_detalle.html
+++ b/templates/app_reservas/aula_detalle.html
@@ -1,46 +1,32 @@
-{% extends 'app_reservas/base.html' %}
+{% extends 'app_reservas/base_calendario.html' %}
 {% load static %}
-
-{% block static_css %}
-    <!--Fullcalendar-Scheduler-->
-    <link rel='stylesheet' href='{% static 'fullcalendar/dist/fullcalendar.min.css' %}' />
-    <link rel='stylesheet' href='{% static 'fullcalendar-scheduler/dist/scheduler.min.css' %}' />
-    <script src='{% static 'moment/min/moment.min.js' %}'></script>
-    <script src='{% static 'jquery/dist/jquery.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/fullcalendar.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/lang/es.js' %}'></script>
-    <script src='{% static 'fullcalendar-scheduler/dist/scheduler.min.js' %}'></script>
-{% endblock %}
 
 {% block title %}
     {{ aula }}
 {% endblock %}
 
+
 {% block contenido %}
+    <h1 style="text-align: center;">{{ aula.get_nombre_corto }}</h1>
+    <h3 style="text-align: center;">{{ aula.nivel }}</h3>
 
-<h1 style="text-align: center;">{{ aula.get_nombre_corto }}</h1>
-<h3 style="text-align: center;">{{ aula.nivel }}</h3>
+    <br />
+    <br />
 
-<br />
-<br />
+    <div id="calendar"></div>
+{% endblock contenido %}
 
-<div id="calendar"></div>
 
-<script>
-    $('#calendar').fullCalendar({
-        defaultView: 'agendaWeek',
-        schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
-        lang: 'es',
-        contentHeight: 'auto',
-        eventSources: [
-            {
-                url: '{% url "recurso_eventos_json" aula.id %}',
-                {% if aula.calendar_color %}
-                    color: '{{ aula.calendar_color }}',
-                {% endif %}
-            },
-        ],
-        minTime: '07:00:00',
-    });
-</script>
+{% block fullcalendar_defaultView %}
+    defaultView: 'agendaWeek',
+{% endblock fullcalendar_defaultView %}
+
+
+{% block fullcalendar_eventSources %}
+    {
+        url: '{% url "recurso_eventos_json" aula.id %}',
+        {% if aula.calendar_color %}
+            color: '{{ aula.calendar_color }}',
+        {% endif %}
+    },
 {% endblock %}

--- a/templates/app_reservas/base.html
+++ b/templates/app_reservas/base.html
@@ -24,7 +24,7 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
 
-    {% block static_js %}{% endblock %}
+    {% block static_js_head %}{% endblock %}
 </head>
 
 <body>
@@ -47,9 +47,13 @@
 <script src='{% static 'bootswatch-dist/js/bootstrap.min.js' %}'></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 <!--<script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>-->
+{% block static_js_body %}{% endblock %}
+
 <script>
     // Resalta la opción del navbar que está siendo visualizada actualmente.
     $('#navbar a[href="' + location.pathname + '"]').parent('li').addClass('active');
 </script>
+
+{% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/app_reservas/base_calendario.html
+++ b/templates/app_reservas/base_calendario.html
@@ -1,0 +1,37 @@
+{% extends 'app_reservas/base.html' %}
+{% load static %}
+
+{% block static_css %}
+    <link rel='stylesheet' href='{% static 'fullcalendar/dist/fullcalendar.min.css' %}' />
+    <link rel='stylesheet' href='{% static 'fullcalendar-scheduler/dist/scheduler.min.css' %}' />
+{% endblock static_css %}
+
+
+{% block static_js_body %}
+    <script src='{% static 'moment/min/moment.min.js' %}'></script>
+    <script src='{% static 'fullcalendar/dist/fullcalendar.min.js' %}'></script>
+    <script src='{% static 'fullcalendar/dist/lang/es.js' %}'></script>
+    <script src='{% static 'fullcalendar-scheduler/dist/scheduler.min.js' %}'></script>
+{% endblock static_js_body %}
+
+
+{% block scripts %}
+    <script>
+        $(document).ready(function() {
+            $('#calendar').fullCalendar({
+                {% block fullcalendar_defaultView %}
+                    defaultView: 'timelineDay',
+                {% endblock %}
+                schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
+                lang: 'es',
+                contentHeight: 'auto',
+                minTime: '07:00:00',
+                {% block fullcalendar_resources %}{% endblock %}
+                eventSources: [
+                    {% block fullcalendar_eventSources %}{% endblock %}
+                ],
+                {% block fullcalendar_opciones %}{% endblock %}
+            });
+        });
+    </script>
+{% endblock scripts %}

--- a/templates/app_reservas/cuerpo_detalle.html
+++ b/templates/app_reservas/cuerpo_detalle.html
@@ -1,27 +1,16 @@
-{% extends 'app_reservas/base.html' %}
+{% extends 'app_reservas/base_calendario.html' %}
 {% load static %}
-
-{% block static_css %}
-    <!--Fullcalendar-Scheduler-->
-    <link rel='stylesheet' href='{% static 'fullcalendar/dist/fullcalendar.min.css' %}' />
-    <link rel='stylesheet' href='{% static 'fullcalendar-scheduler/dist/scheduler.min.css' %}' />
-    <script src='{% static 'moment/min/moment.min.js' %}'></script>
-    <script src='{% static 'jquery/dist/jquery.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/fullcalendar.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/lang/es.js' %}'></script>
-    <script src='{% static 'fullcalendar-scheduler/dist/scheduler.min.js' %}'></script>
-{% endblock %}
 
 {% block title %}
     {{ cuerpo.get_nombre_corto }}
 {% endblock %}
 
+
 {% block contenido %}
+    <h1 style="text-align: center;">{{ cuerpo.get_nombre_corto }}</h1>
 
-<h1 style="text-align: center;">{{ cuerpo.get_nombre_corto }}</h1>
-
-<br />
-<br />
+    <br />
+    <br />
 
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
         {% for nivel in cuerpo.get_niveles %}
@@ -178,73 +167,70 @@
     <br />
 
     <div id="calendar"></div>
+{% endblock contenido %}
 
+
+{% block scripts %}
+    {{ block.super }}
 
     <script>
         $(function () {
             $('[data-toggle="tooltip"]').tooltip()
         });
     </script>
+{% endblock %}
 
-<script>
-    var current_date = new Date();
-    var last_hour = (current_date.getHours() - 1) + ":00:00";
 
-    $('#calendar').fullCalendar({
-        defaultView: 'timelineDay',
-        schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
-        lang: 'es',
-        contentHeight: 'auto',
-        resourceColumns: [
+{% block fullcalendar_resources %}
+    resourceColumns: [
+        {
+            group: true,
+            labelText: 'Nivel',
+            field: 'nivel'
+        },
+        {
+            labelText: 'Recurso',
+            field: 'title'
+        },
+    ],
+    resources: [
+        {% for nivel in cuerpo.get_niveles %}
+            {% for aula in nivel.get_aulas %}
+                {
+                    id: '{{ aula.id }}',
+                    nivel: '{{ nivel.get_nombre_corto }}',
+                    title: '{{ aula.get_nombre_corto }}',
+                },
+            {% endfor %}
+            {% for laboratorio in nivel.get_laboratorios_informaticos %}
+                {
+                    id: '{{ laboratorio.id }}',
+                    nivel: '{{ nivel.get_nombre_corto }}',
+                    title: '{{ laboratorio.get_nombre_corto }}',
+                },
+            {% endfor %}
+        {% endfor %}
+    ],
+{% endblock fullcalendar_resources %}
+
+
+{% block fullcalendar_eventSources %}
+    {% for nivel in cuerpo.get_niveles %}
+        {% for aula in nivel.get_aulas %}
             {
-                group: true,
-				labelText: 'Nivel',
-				field: 'nivel'
+                url: '{% url "recurso_eventos_json" aula.id %}',
+                {% if aula.calendar_color %}
+                    color: '{{ aula.calendar_color }}',
+                {% endif %}
             },
-			{
-				labelText: 'Aula',
-				field: 'title'
-			},
-        ],
-        resources: [
-            {% for nivel in cuerpo.get_niveles %}
-                {% for aula in nivel.get_aulas %}
-                    {
-                        id: '{{ aula.id }}',
-                        nivel: '{{ nivel.get_nombre_corto }}',
-                        title: '{{ aula.get_nombre_corto }}',
-                    },
-                {% endfor %}
-                {% for laboratorio in nivel.get_laboratorios_informaticos %}
-                    {
-                        id: '{{ laboratorio.id }}',
-                        nivel: '{{ nivel.get_nombre_corto }}',
-                        title: '{{ laboratorio.get_nombre_corto }}',
-                    },
-                {% endfor %}
-            {% endfor %}
-        ],
-        eventSources: [
-            {% for nivel in cuerpo.get_niveles %}
-                {% for aula in nivel.get_aulas %}
-                    {
-                        url: '{% url "recurso_eventos_json" aula.id %}',
-                        {% if aula.calendar_color %}
-                            color: '{{ aula.calendar_color }}',
-                        {% endif %}
-                    },
-                {% endfor %}
-                {% for laboratorio in nivel.get_laboratorios_informaticos %}
-                    {
-                        url: '{% url "recurso_eventos_json" laboratorio.id %}',
-                        {% if laboratorio.calendar_color %}
-                            color: '{{ laboratorio.calendar_color }}',
-                        {% endif %}
-                    },
-                {% endfor %}
-            {% endfor %}
-        ],
-        minTime: '07:00:00',
-    });
-</script>
+        {% endfor %}
+        {% for laboratorio in nivel.get_laboratorios_informaticos %}
+            {
+                url: '{% url "recurso_eventos_json" laboratorio.id %}',
+                {% if laboratorio.calendar_color %}
+                    color: '{{ laboratorio.calendar_color }}',
+                {% endif %}
+            },
+        {% endfor %}
+    {% endfor %}
 {% endblock %}

--- a/templates/app_reservas/laboratorio_informatico_detalle.html
+++ b/templates/app_reservas/laboratorio_informatico_detalle.html
@@ -1,46 +1,32 @@
-{% extends 'app_reservas/base.html' %}
+{% extends 'app_reservas/base_calendario.html' %}
 {% load static %}
-
-{% block static_css %}
-    <!--Fullcalendar-Scheduler-->
-    <link rel='stylesheet' href='{% static 'fullcalendar/dist/fullcalendar.min.css' %}' />
-    <link rel='stylesheet' href='{% static 'fullcalendar-scheduler/dist/scheduler.min.css' %}' />
-    <script src='{% static 'moment/min/moment.min.js' %}'></script>
-    <script src='{% static 'jquery/dist/jquery.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/fullcalendar.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/lang/es.js' %}'></script>
-    <script src='{% static 'fullcalendar-scheduler/dist/scheduler.min.js' %}'></script>
-{% endblock %}
 
 {% block title %}
     {{ laboratorio }}
 {% endblock %}
 
+
 {% block contenido %}
+    <h1 style="text-align: center;">{{ laboratorio }}</h1>
+    <h3 style="text-align: center;">{{ laboratorio.nivel }}</h3>
 
-<h1 style="text-align: center;">{{ laboratorio }}</h1>
-<h3 style="text-align: center;">{{ laboratorio.nivel }}</h3>
+    <br />
+    <br />
 
-<br />
-<br />
+    <div id="calendar"></div>
+{% endblock contenido %}
 
-<div id="calendar"></div>
 
-<script>
-    $('#calendar').fullCalendar({
-        defaultView: 'agendaWeek',
-        schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
-        lang: 'es',
-        contentHeight: 'auto',
-        eventSources: [
-            {
-                url: '{% url "recurso_eventos_json" laboratorio.id %}',
-                {% if laboratorio.calendar_color %}
-                    color: '{{ laboratorio.calendar_color }}',
-                {% endif %}
-            },
-        ],
-        minTime: '07:00:00',
-    });
-</script>
+{% block fullcalendar_defaultView %}
+    defaultView: 'agendaWeek',
+{% endblock fullcalendar_defaultView %}
+
+
+{% block fullcalendar_eventSources %}
+    {
+        url: '{% url "recurso_eventos_json" laboratorio.id %}',
+        {% if laboratorio.calendar_color %}
+            color: '{{ laboratorio.calendar_color }}',
+        {% endif %}
+    },
 {% endblock %}

--- a/templates/app_reservas/laboratorio_informatico_listado.html
+++ b/templates/app_reservas/laboratorio_informatico_listado.html
@@ -1,24 +1,13 @@
-{% extends 'app_reservas/base.html' %}
+{% extends 'app_reservas/base_calendario.html' %}
 {% load static %}
-
-{% block static_css %}
-    <!--Fullcalendar-Scheduler-->
-    <link rel='stylesheet' href='{% static 'fullcalendar/dist/fullcalendar.min.css' %}' />
-    <link rel='stylesheet' href='{% static 'fullcalendar-scheduler/dist/scheduler.min.css' %}' />
-    <script src='{% static 'moment/min/moment.min.js' %}'></script>
-    <script src='{% static 'jquery/dist/jquery.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/fullcalendar.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/lang/es.js' %}'></script>
-    <script src='{% static 'fullcalendar-scheduler/dist/scheduler.min.js' %}'></script>
-{% endblock %}
 
 {% block title %}
     Laboratorios informáticos
 {% endblock %}
 
-{% block contenido %}
 
-<h1 style="text-align: center;">Laboratorios informáticos</h1>
+{% block contenido %}
+    <h1 style="text-align: center;">Laboratorios informáticos</h1>
 
     <br/>
     <br/>
@@ -97,42 +86,40 @@
     <br />
 
     <div id="calendar"></div>
+{% endblock contenido %}
+
+
+{% block scripts %}
+    {{ block.super }}
 
     <script>
         $(function () {
             $('[data-toggle="tooltip"]').tooltip()
         });
     </script>
+{% endblock %}
 
-    <script>
-        var current_date = new Date();
-        var last_hour = (current_date.getHours() - 1) + ":00:00";
 
-        $('#calendar').fullCalendar({
-            defaultView: 'timelineDay',
-            schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
-            lang: 'es',
-            contentHeight: 'auto',
-            resourceLabelText: 'Laboratorio informático',
-            resources: [
-                {% for laboratorio in laboratorios %}
-                    {
-                        id: '{{ laboratorio.id }}',
-                        title: '{{ laboratorio.get_nombre_corto }}',
-                    },
-                {% endfor %}
-            ],
-            eventSources: [
-                {% for laboratorio in laboratorios %}
-                    {
-                        url: '{% url "recurso_eventos_json" laboratorio.id %}',
-                        {% if laboratorio.calendar_color %}
-                            color: '{{ laboratorio.calendar_color }}',
-                        {% endif %}
-                    },
-                {% endfor %}
-            ],
-            minTime: '07:00:00',
-        });
-    </script>
+{% block fullcalendar_resources %}
+    resourceLabelText: 'Laboratorio informático',
+    resources: [
+        {% for laboratorio in laboratorios %}
+            {
+                id: '{{ laboratorio.id }}',
+                title: '{{ laboratorio.get_nombre_corto }}',
+            },
+        {% endfor %}
+    ],
+{% endblock fullcalendar_resources %}
+
+
+{% block fullcalendar_eventSources %}
+    {% for laboratorio in laboratorios %}
+        {
+            url: '{% url "recurso_eventos_json" laboratorio.id %}',
+            {% if laboratorio.calendar_color %}
+                color: '{{ laboratorio.calendar_color }}',
+            {% endif %}
+        },
+    {% endfor %}
 {% endblock %}

--- a/templates/app_reservas/nivel_detalle.html
+++ b/templates/app_reservas/nivel_detalle.html
@@ -1,25 +1,14 @@
-{% extends 'app_reservas/base.html' %}
+{% extends 'app_reservas/base_calendario.html' %}
 {% load static %}
-
-{% block static_css %}
-    <!--Fullcalendar-Scheduler-->
-    <link rel='stylesheet' href='{% static 'fullcalendar/dist/fullcalendar.min.css' %}' />
-    <link rel='stylesheet' href='{% static 'fullcalendar-scheduler/dist/scheduler.min.css' %}' />
-    <script src='{% static 'moment/min/moment.min.js' %}'></script>
-    <script src='{% static 'jquery/dist/jquery.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/fullcalendar.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/lang/es.js' %}'></script>
-    <script src='{% static 'fullcalendar-scheduler/dist/scheduler.min.js' %}'></script>
-{% endblock %}
 
 {% block title %}
     {{ nivel }}
 {% endblock %}
 
-{% block contenido %}
 
-<h1 style="text-align: center;">{{ nivel.get_nombre_corto }}</h1>
-<h3 style="text-align: center;">{{ nivel.cuerpo.get_nombre_corto }}</h3>
+{% block contenido %}
+    <h1 style="text-align: center;">{{ nivel.get_nombre_corto }}</h1>
+    <h3 style="text-align: center;">{{ nivel.cuerpo.get_nombre_corto }}</h3>
 
     <br/>
     <br/>
@@ -170,60 +159,58 @@
         {% endif %}
     </div>
 
-<br />
-<br />
+    <br />
+    <br />
 
-<div id="calendar"></div>
+    <div id="calendar"></div>
+{% endblock contenido %}
+
+
+{% block scripts %}
+    {{ block.super }}
 
     <script>
         $(function () {
             $('[data-toggle="tooltip"]').tooltip()
         });
     </script>
+{% endblock %}
 
-<script>
-    var current_date = new Date();
-    var last_hour = (current_date.getHours() - 1) + ":00:00";
 
-    $('#calendar').fullCalendar({
-        defaultView: 'timelineDay',
-        schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
-        lang: 'es',
-        contentHeight: 'auto',
-        resourceLabelText: 'Aula',
-        resources: [
-            {% for aula in nivel.get_aulas %}
-                {
-                    id: '{{ aula.id }}',
-                    title: '{{ aula.get_nombre_corto }}',
-                },
-            {% endfor %}
-            {% for laboratorio in nivel.get_laboratorios_informaticos %}
-                {
-                    id: '{{ laboratorio.id }}',
-                    title: '{{ laboratorio.get_nombre_corto }}',
-                },
-            {% endfor %}
-        ],
-        eventSources: [
-            {% for aula in nivel.get_aulas %}
-                {
-                    url: '{% url "recurso_eventos_json" aula.id %}',
-                    {% if aula.calendar_color %}
-                        color: '{{ aula.calendar_color }}',
-                    {% endif %}
-                },
-            {% endfor %}
-            {% for laboratorio in nivel.get_laboratorios_informaticos %}
-                {
-                    url: '{% url "recurso_eventos_json" laboratorio.id %}',
-                    {% if laboratorio.calendar_color %}
-                        color: '{{ laboratorio.calendar_color }}',
-                    {% endif %}
-                },
-            {% endfor %}
-        ],
-        minTime: '07:00:00',
-    });
-</script>
+{% block fullcalendar_resources %}
+    resourceLabelText: 'Recurso',
+    resources: [
+        {% for aula in nivel.get_aulas %}
+            {
+                id: '{{ aula.id }}',
+                title: '{{ aula.get_nombre_corto }}',
+            },
+        {% endfor %}
+        {% for laboratorio in nivel.get_laboratorios_informaticos %}
+            {
+                id: '{{ laboratorio.id }}',
+                title: '{{ laboratorio.get_nombre_corto }}',
+            },
+        {% endfor %}
+    ],
+{% endblock fullcalendar_resources %}
+
+
+{% block fullcalendar_eventSources %}
+    {% for aula in nivel.get_aulas %}
+        {
+            url: '{% url "recurso_eventos_json" aula.id %}',
+            {% if aula.calendar_color %}
+                color: '{{ aula.calendar_color }}',
+            {% endif %}
+        },
+    {% endfor %}
+    {% for laboratorio in nivel.get_laboratorios_informaticos %}
+        {
+            url: '{% url "recurso_eventos_json" laboratorio.id %}',
+            {% if laboratorio.calendar_color %}
+                color: '{{ laboratorio.calendar_color }}',
+            {% endif %}
+        },
+    {% endfor %}
 {% endblock %}

--- a/templates/app_reservas/proyector_multimedia_detalle.html
+++ b/templates/app_reservas/proyector_multimedia_detalle.html
@@ -1,45 +1,30 @@
-{% extends 'app_reservas/base.html' %}
+{% extends 'app_reservas/base_calendario.html' %}
 {% load static %}
-
-{% block static_css %}
-    <!--Fullcalendar-Scheduler-->
-    <link rel='stylesheet' href='{% static 'fullcalendar/dist/fullcalendar.min.css' %}' />
-    <link rel='stylesheet' href='{% static 'fullcalendar-scheduler/dist/scheduler.min.css' %}' />
-    <script src='{% static 'moment/min/moment.min.js' %}'></script>
-    <script src='{% static 'jquery/dist/jquery.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/fullcalendar.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/lang/es.js' %}'></script>
-    <script src='{% static 'fullcalendar-scheduler/dist/scheduler.min.js' %}'></script>
-{% endblock %}
 
 {% block title %}
     {{ proyector }}
 {% endblock %}
 
 {% block contenido %}
+    <h1 style="text-align: center;">{{ proyector }}</h1>
 
-<h1 style="text-align: center;">{{ proyector }}</h1>
+    <br />
+    <br />
 
-<br />
-<br />
+    <div id="calendar"></div>
+    {% endblock contenido %}
 
-<div id="calendar"></div>
 
-<script>
-    $('#calendar').fullCalendar({
-        defaultView: 'agendaWeek',
-        schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
-        lang: 'es',
-        contentHeight: 'auto',
-        eventSources: [
-            {
-                url: '{% url "recurso_eventos_json" proyector.id %}',
-                {% if proyector.calendar_color %}
-                    color: '{{ proyector.calendar_color }}',
-                {% endif %}
-            },
-        ],
-        minTime: '07:00:00',
-    });
-</script>
+{% block fullcalendar_defaultView %}
+    defaultView: 'agendaWeek',
+{% endblock fullcalendar_defaultView %}
+
+
+{% block fullcalendar_eventSources %}
+    {
+        url: '{% url "recurso_eventos_json" proyector.id %}',
+        {% if proyector.calendar_color %}
+            color: '{{ proyector.calendar_color }}',
+        {% endif %}
+    },
 {% endblock %}

--- a/templates/app_reservas/proyector_multimedia_listado.html
+++ b/templates/app_reservas/proyector_multimedia_listado.html
@@ -1,23 +1,11 @@
-{% extends 'app_reservas/base.html' %}
+{% extends 'app_reservas/base_calendario.html' %}
 {% load static %}
-
-{% block static_css %}
-    <!--Fullcalendar-Scheduler-->
-    <link rel='stylesheet' href='{% static 'fullcalendar/dist/fullcalendar.min.css' %}' />
-    <link rel='stylesheet' href='{% static 'fullcalendar-scheduler/dist/scheduler.min.css' %}' />
-    <script src='{% static 'moment/min/moment.min.js' %}'></script>
-    <script src='{% static 'jquery/dist/jquery.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/fullcalendar.min.js' %}'></script>
-    <script src='{% static 'fullcalendar/dist/lang/es.js' %}'></script>
-    <script src='{% static 'fullcalendar-scheduler/dist/scheduler.min.js' %}'></script>
-{% endblock %}
 
 {% block title %}
     Proyectores multimedia
 {% endblock %}
 
 {% block contenido %}
-
     <h1 style="text-align: center;">Proyectores multimedia</h1>
 
     <br/>
@@ -87,42 +75,40 @@
     <br />
 
     <div id="calendar"></div>
+{% endblock contenido %}
+
+
+{% block scripts %}
+    {{ block.super }}
 
     <script>
         $(function () {
             $('[data-toggle="tooltip"]').tooltip()
         });
     </script>
+{% endblock %}
 
-    <script>
-        var current_date = new Date();
-        var last_hour = (current_date.getHours() - 1) + ":00:00";
 
-        $('#calendar').fullCalendar({
-            defaultView: 'timelineDay',
-            schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
-            lang: 'es',
-            contentHeight: 'auto',
-            resourceLabelText: 'Proyector multimedia',
-            resources: [
-                {% for proyector in proyectores %}
-                    {
-                        id: '{{ proyector.id }}',
-                        title: '{{ proyector.get_nombre_corto }}',
-                    },
-                {% endfor %}
-            ],
-            eventSources: [
-                {% for proyector in proyectores %}
-                    {
-                        url: '{% url "recurso_eventos_json" proyector.id %}',
-                        {% if proyector.calendar_color %}
-                            color: '{{ proyector.calendar_color }}',
-                        {% endif %}
-                    },
-                {% endfor %}
-            ],
-            minTime: '07:00:00',
-        });
-    </script>
+{% block fullcalendar_resources %}
+    resourceLabelText: 'Proyector multimedia',
+    resources: [
+        {% for proyector in proyectores %}
+            {
+                id: '{{ proyector.id }}',
+                title: '{{ proyector.get_nombre_corto }}',
+            },
+        {% endfor %}
+    ],
+{% endblock fullcalendar_resources %}
+
+
+{% block fullcalendar_eventSources %}
+    {% for proyector in proyectores %}
+        {
+            url: '{% url "recurso_eventos_json" proyector.id %}',
+            {% if proyector.calendar_color %}
+                color: '{{ proyector.calendar_color }}',
+            {% endif %}
+        },
+    {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Se añade la **plantilla `base_calendario`**, que sirve de base a las páginas que incluyen un calendario de **FullCalendar**. Especifica las importaciones necesarias, y las opciones comunes del calendario.
