### PR TITLE
Inclusión de datepicker asociado a FullCalendar

### DIFF
--- a/reservas/settings/base.py
+++ b/reservas/settings/base.py
@@ -143,6 +143,7 @@ MEDIA_URL = '/' + DJANGO_URL_PREFIX + 'media/'
 BOWER_COMPONENTS_ROOT = os.path.join(BASE_DIR, 'components')
 
 BOWER_INSTALLED_APPS = (
+    'bootstrap-datepicker',
     'bootswatch-dist#flatly',
     'fullcalendar-scheduler',
     'handsontable',

--- a/templates/app_reservas/base_calendario.html
+++ b/templates/app_reservas/base_calendario.html
@@ -4,6 +4,7 @@
 {% block static_css %}
     <link rel='stylesheet' href='{% static 'fullcalendar/dist/fullcalendar.min.css' %}' />
     <link rel='stylesheet' href='{% static 'fullcalendar-scheduler/dist/scheduler.min.css' %}' />
+    <link rel="stylesheet" href='{% static 'bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css' %}' />
 {% endblock static_css %}
 
 
@@ -12,6 +13,8 @@
     <script src='{% static 'fullcalendar/dist/fullcalendar.min.js' %}'></script>
     <script src='{% static 'fullcalendar/dist/lang/es.js' %}'></script>
     <script src='{% static 'fullcalendar-scheduler/dist/scheduler.min.js' %}'></script>
+    <script src='{% static 'bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js' %}'></script>
+    <script src='{% static 'bootstrap-datepicker/dist/locales/bootstrap-datepicker.es.min.js' %}'></script>
 {% endblock static_js_body %}
 
 
@@ -30,7 +33,32 @@
                 eventSources: [
                     {% block fullcalendar_eventSources %}{% endblock %}
                 ],
+                customButtons: {
+                    datepickerButton: {
+                        text: 'Calendario',
+                    }
+                },
+                header: {
+                    left: 'prev,next today datepickerButton',
+                    center: 'title',
+                    right: '',
+                }
                 {% block fullcalendar_opciones %}{% endblock %}
+            });
+        });
+    </script>
+
+    <script>
+    $(document).ready(function() {
+        $('.fc-datepickerButton-button').datepicker({
+            format: 'dd/mm/yyyy',
+            language: 'es',
+            daysOfWeekDisabled: '0',
+            autoclose: true,
+            todayHighlight: true
+        })
+            .on('changeDate', function(e) {
+                $('#calendar').fullCalendar('gotoDate', e.date);
             });
         });
     </script>


### PR DESCRIPTION
Se instala **bootstrap-datepicker** **[1]** mediante _bower_, y se añade un botón personalizado **[2]** a los calendarios de **FullCalendar**, que muestra el _datepicker_ y cambia la fecha visualizada en el calendario. **[3]** **[4]** **[5]**

**[1]** https://github.com/eternicode/bootstrap-datepicker
**[2]** http://fullcalendar.io/docs/display/customButtons/
**[3]** https://code.google.com/p/fullcalendar/issues/detail?id=167
**[4]** https://code.google.com/p/fullcalendar/issues/detail?id=225
**[5]** https://stackoverflow.com/questions/7878898/how-to-combine-jquery-date-picker-and-jquery-full-calendar
