### PR TITLE
Corrección en la ejecución de django-bower con parámetros

### DIFF
--- a/run-django.sh
+++ b/run-django.sh
@@ -16,7 +16,7 @@ function pg_wait {
 pg_wait
 
 python manage.py migrate
-python manage.py bower install -- --allow-root
+python manage.py bower_install -- --allow-root
 python manage.py collectstatic --noinput
 
 gunicorn reservas.wsgi:application -b :8000


### PR DESCRIPTION
Se corrige la ejecución del comando `bower install` de **django-bower**, debido a un _bug_ **[1]** cuando se ejecuta con parámetros.

**[1]** https://github.com/nvbn/django-bower/issues/51
