### PR TITLE
Inclusión de enlace a repositorio de GitHub en navbar

### DIFF
--- a/templates/app_reservas/navbar.html
+++ b/templates/app_reservas/navbar.html
@@ -92,6 +92,14 @@
                     </ul>
                 </li>
             </ul>
+            <ul class="nav navbar-nav navbar-right">
+                <li>
+                    <a href='https://github.com/utn-frm-si/reservas'
+                       target='_blank'>
+                        <i class="fa fa- fa-github fa-lg fa-fw"></i>&nbsp;<span class="hidden-sm">GitHub</span>
+                    </a>
+                </li>
+            </ul>
         </div><!--/.nav-collapse -->
     </div>
 </nav>


### PR DESCRIPTION
Se añade el **enlace al repositorio de GitHub** como elemento alineado a la derecha del _navbar_, para promover la contribución y difusión del proyecto.
