### PR TITLE
Agregación de archivos de ubicación para laboratorios informáticos

### DIFF
--- a/app_reservas/migrations/0010_archivo_ubicacion_laboratorio_informatico.py
+++ b/app_reservas/migrations/0010_archivo_ubicacion_laboratorio_informatico.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import app_reservas.models.LaboratorioInformatico
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('app_reservas', '0009_clase_proyector_multimedia'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='laboratorioinformatico',
+            name='archivo_ubicacion',
+            field=models.FileField(upload_to=app_reservas.models.LaboratorioInformatico.establecer_destino_archivo_ubicacion, blank=True),
+        ),
+    ]

--- a/app_reservas/models/LaboratorioInformatico.py
+++ b/app_reservas/models/LaboratorioInformatico.py
@@ -1,8 +1,19 @@
 # coding=utf-8
 
+import os
+
 from django.db import models
+from django.template.defaultfilters import slugify
 
 from .Recurso import Recurso
+
+
+def establecer_destino_archivo_ubicacion(instance, filename):
+    # Almacena el archivo en: 'app_reservas/ubicaciones/laboratorios_informaticos/<alias_del_laboratorio_informatico>.<extension>'
+    ruta_archivos_ubicacion = 'app_reservas/ubicaciones/laboratorios_informaticos/'
+    extension_archivo = filename.split('.')[-1] if '.' in filename else ''
+    nombre_archivo = '%s.%s' % (slugify(instance.alias), extension_archivo)
+    return os.path.join(ruta_archivos_ubicacion, nombre_archivo)
 
 
 class LaboratorioInformatico(Recurso):
@@ -10,6 +21,7 @@ class LaboratorioInformatico(Recurso):
     nombre = models.CharField(max_length=50)
     alias = models.CharField(max_length=10)
     capacidad = models.PositiveSmallIntegerField()
+    archivo_ubicacion = models.FileField(upload_to=establecer_destino_archivo_ubicacion, blank=True)
     # Relaciones
     nivel = models.ForeignKey('Nivel')
 
@@ -19,6 +31,11 @@ class LaboratorioInformatico(Recurso):
 
     def get_nombre_corto(self):
         return '%s (%s)' % (self.nombre, self.alias)
+
+    # FIXME: Método necesario para que la migración funcione correctamente.
+    @staticmethod
+    def establecer_destino_archivo_ubicacion(instance, filename):
+        return establecer_destino_archivo_ubicacion(instance, filename)
 
     # Información de la clase
     class Meta:

--- a/templates/app_reservas/cuerpo_detalle.html
+++ b/templates/app_reservas/cuerpo_detalle.html
@@ -150,6 +150,18 @@
                                                           aria-hidden="true">
                                                     </span>
                                                 </a>
+                                                {% if laboratorio.archivo_ubicacion %}
+                                                    <a role="button"
+                                                       class="btn btn-xs btn-success"
+                                                       data-toggle="tooltip"
+                                                       data-placement="bottom"
+                                                       title="Ubicación"
+                                                       href="{{ laboratorio.archivo_ubicacion.url }}">
+                                                        <span class="glyphicon glyphicon-map-marker"
+                                                              aria-hidden="true">
+                                                        </span>
+                                                    </a>
+                                                {% endif %}
                                             </td>
                                         </tr>
                                     {% endfor %}

--- a/templates/app_reservas/laboratorio_informatico_listado.html
+++ b/templates/app_reservas/laboratorio_informatico_listado.html
@@ -66,6 +66,18 @@
                                                       aria-hidden="true">
                                                 </span>
                                             </a>
+                                            {% if laboratorio.archivo_ubicacion %}
+                                                <a role="button"
+                                                   class="btn btn-xs btn-success"
+                                                   data-toggle="tooltip"
+                                                   data-placement="bottom"
+                                                   title="Ubicación"
+                                                   href="{{ laboratorio.archivo_ubicacion.url }}">
+                                                    <span class="glyphicon glyphicon-map-marker"
+                                                          aria-hidden="true">
+                                                    </span>
+                                                </a>
+                                            {% endif %}
                                         </td>
                                     </tr>
                                 {% endfor %}

--- a/templates/app_reservas/nivel_detalle.html
+++ b/templates/app_reservas/nivel_detalle.html
@@ -147,6 +147,18 @@
                                                       aria-hidden="true">
                                                 </span>
                                             </a>
+                                            {% if laboratorio.archivo_ubicacion %}
+                                                <a role="button"
+                                                   class="btn btn-xs btn-success"
+                                                   data-toggle="tooltip"
+                                                   data-placement="bottom"
+                                                   title="Ubicación"
+                                                   href="{{ laboratorio.archivo_ubicacion.url }}">
+                                                    <span class="glyphicon glyphicon-map-marker"
+                                                          aria-hidden="true">
+                                                    </span>
+                                                </a>
+                                            {% endif %}
                                         </td>
                                     </tr>
                                 {% endfor %}


### PR DESCRIPTION
Se añade el **campo `archivo_ubicacion`** al modelo _LaboratorioInformatico_, para poder cargar un archivo que indique la ubicación del mismo, al igual que se contempla actualmente con las aulas. También se crea la **migración** necesaria, y el **enlace al archivo en las vistas** que listan laboratorios informáticos.
