### PR TITLE
Inclusión de indicador de hora actual en calendarios

### DIFF
--- a/templates/app_reservas/base_calendario.html
+++ b/templates/app_reservas/base_calendario.html
@@ -29,6 +29,7 @@
                 lang: 'es',
                 contentHeight: 'auto',
                 minTime: '07:00:00',
+                nowIndicator: true,
                 {% block fullcalendar_resources %}{% endblock %}
                 eventSources: [
                     {% block fullcalendar_eventSources %}{% endblock %}
@@ -49,17 +50,17 @@
     </script>
 
     <script>
-    $(document).ready(function() {
-        $('.fc-datepickerButton-button').datepicker({
-            format: 'dd/mm/yyyy',
-            language: 'es',
-            daysOfWeekDisabled: '0',
-            autoclose: true,
-            todayHighlight: true
-        })
-            .on('changeDate', function(e) {
-                $('#calendar').fullCalendar('gotoDate', e.date);
-            });
+        $(document).ready(function() {
+            $('.fc-datepickerButton-button').datepicker({
+                format: 'dd/mm/yyyy',
+                language: 'es',
+                daysOfWeekDisabled: '0',
+                autoclose: true,
+                todayHighlight: true
+            })
+                .on('changeDate', function(e) {
+                    $('#calendar').fullCalendar('gotoDate', e.date);
+                });
         });
     </script>
 {% endblock scripts %}


### PR DESCRIPTION
Se añade por defecto un **indicador que marca la hora actual** en los calendarios, funcionalidad agregada en la versión `2.6.0` de **FullCalendar** (versión `1.2.0` de **FullCalendar-Scheduler**). **[1]**

Además, se indenta correctamente el _script_ que construye el _datepicker_ para el calendario.

**[1]** http://fullcalendar.io/docs/current_date/nowIndicator/
