### PR TITLE
Interacción bidireccional entre Fullcalendar y datepicker

### DIFF
--- a/templates/app_reservas/base_calendario.html
+++ b/templates/app_reservas/base_calendario.html
@@ -43,7 +43,27 @@
                     left: 'prev,next today datepickerButton',
                     center: 'title',
                     right: '',
-                }
+                },
+                viewRender: function(view, element) {
+                    // Obtiene el objeto asociado al datepicker.
+                    var datepicker = $('.fc-datepickerButton-button');
+                    // Comprueba que el datepicker ya haya sido cargado. Sino, retorna.
+                    if (! datepicker.data('datepicker')) {
+                        return;
+                    };
+                    // Obtiene las fechas establecidas, en el calendario y en el datepicker.
+                    var fechaFullcalendar = new Date(view.intervalStart);
+                    var fechaDatepicker = new Date(datepicker.datepicker('getDate'));
+                    // Crea momentos en base a las fechas, especificadas en UTC.
+                    var momentoFullcalendar = moment(fechaFullcalendar).utc();
+                    var momentoDatepicker = moment(fechaDatepicker).utc();
+                    // Comprueba que los días indicados por ambas fechas sean distintos.
+                    // En caso de serlo, actualiza la fecha del datepicker para que refleje
+                    // correctamente el estado actual del calendario.
+                    if (! momentoFullcalendar.isSame(momentoDatepicker, 'day')) {
+                        datepicker.datepicker('setUTCDate', momentoFullcalendar.toDate());
+                    };
+                },
                 {% block fullcalendar_opciones %}{% endblock %}
             });
         });


### PR DESCRIPTION
Hasta el momento, sólo se actualizaba **Fullcalendar** en base a la fecha seleccionada en el **_datepicker_**, pero no se contaba con la actualización del _datepicker_ cuando se navegaba por los días desde el calendario.

Mediante el _callback_ `viewRender` **[1]** de **Fullcalendar**, se implementa la interacción en el sentido `Fullcalendar -> Datepicker`, haciendo uso de **moment.js** **[2]** para la obtención, manejo y comparación de fechas.

**[1]** http://fullcalendar.io/docs/display/viewRender/
**[2]** http://momentjs.com/
