### PR TITLE
Ocultamiento de navbar brand en resoluciones medianas y pequeñas

### DIFF
--- a/templates/app_reservas/navbar.html
+++ b/templates/app_reservas/navbar.html
@@ -7,13 +7,13 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="{% url 'index' %}">Administración de aulas</a>
+            <a class="navbar-brand hidden-sm hidden-md" href="{% url 'index' %}">Administración de aulas</a>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
                 <li>
                     <a href="{% url 'index' %}">
-                        <i class="fa fa-home fa-lg fa-fw"></i> &nbsp; Inicio
+                        <i class="fa fa-home fa-lg fa-fw"></i>&nbsp;Inicio
                     </a>
                 </li>
                 <li class="dropdown">
@@ -23,7 +23,7 @@
                        role="button"
                        aria-haspopup="true"
                        aria-expanded="false">
-                        <i class="fa fa-university fa-lg fa-fw"></i> &nbsp; Distribución física <span class="caret"></span>
+                        <i class="fa fa-university fa-lg fa-fw"></i>&nbsp;Distribución física <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
                         {% for cuerpo in lista_cuerpos %}
@@ -42,7 +42,7 @@
                        role="button"
                        aria-haspopup="true"
                        aria-expanded="false">
-                        <i class="fa fa-book fa-lg fa-fw"></i> &nbsp; Aulas <span class="caret"></span>
+                        <i class="fa fa-book fa-lg fa-fw"></i>&nbsp;Aulas <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
                         {% for area in lista_areas %}
@@ -61,7 +61,7 @@
                        role="button"
                        aria-haspopup="true"
                        aria-expanded="false">
-                        <i class="fa fa-desktop fa-lg fa-fw"></i> &nbsp; ALI <span class="caret"></span>
+                        <i class="fa fa-desktop fa-lg fa-fw"></i>&nbsp;ALI <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
                         <li>
@@ -83,7 +83,7 @@
                        role="button"
                        aria-haspopup="true"
                        aria-expanded="false">
-                        <i class="fa fa- fa-pencil-square-o fa-lg fa-fw"></i> &nbsp; Solicitudes <span class="caret"></span>
+                        <i class="fa fa- fa-pencil-square-o fa-lg fa-fw"></i>&nbsp;Solicitudes <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
                         <li><a href="{% url 'solicitud_aula' %}">Aula</a></li>


### PR DESCRIPTION
Se oculta el _navbar brand_ en resoluciones medianas (`md`) y pequeñas (`sm`), para evitar que el _navbar_ se muestre en múltiples filas **[1]**. Para efectuar el ocultamiento, se hace uso de las **utilidades responsivas de Bootstrap 3**. **[2]**

**[1]** https://stackoverflow.com/questions/20012665/disable-bootstrap-3-navbar-going-2-rows-in-medium-viewport-size
**[2]** https://getbootstrap.com/css/#responsive-utilities
