### PR TITLE
Inclusión de indicador de carga para Fullcalendar

### DIFF
--- a/templates/app_reservas/base_calendario.html
+++ b/templates/app_reservas/base_calendario.html
@@ -64,6 +64,15 @@
                         datepicker.datepicker('setUTCDate', momentoFullcalendar.toDate());
                     };
                 },
+                loading: function(isLoading, view) {
+                    if (isLoading) {
+                        loadingSpinner = $('<i id="calendar_loading_indicator" class="fa fa-2x fa-spinner fa-spin"></i>');
+                        $('.fc-left').append(loadingSpinner);
+                    }
+                    else {
+                        $('#calendar_loading_indicator').remove();
+                    }
+                },
                 {% block fullcalendar_opciones %}{% endblock %}
             });
         });


### PR DESCRIPTION
Mediante el **_callback_ `loading`** **[1]** de Fullcalendar, se añade un **indicador de carga de eventos**, para notificar cuándo se han concretado las peticiones de eventos al servidor. **[2]**

**[1]** http://fullcalendar.io/docs/event_data/loading/
**[2]** https://github.com/oneiros/kalua/blob/1ee72f6cd07d10c17019d112306f1673c0ae33b5/public/javascripts/show_calendar.js
