### PR TITLE
Inclusión de ícono en botón de datepicker del calendario

### DIFF
--- a/templates/app_reservas/base_calendario.html
+++ b/templates/app_reservas/base_calendario.html
@@ -37,6 +37,7 @@
                 customButtons: {
                     datepickerButton: {
                         text: 'Calendario',
+                        icon: 'datepicker',
                     }
                 },
                 header: {
@@ -75,6 +76,9 @@
                 },
                 {% block fullcalendar_opciones %}{% endblock %}
             });
+
+            // Añade el ícono personalizado al botón del datepicker.
+            $('.fc-icon-datepicker').append('<i class="fa fa-calendar"></i>')
         });
     </script>
 


### PR DESCRIPTION
Se añade el ícono correspondiente de **Font-Awesome**, al botón personalizado de _datepicker_ en Fullcalendar.
