### PR TITLE
Inclusión de badge de 'Code Climate' en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # reservas
 
-[![Requirements Status](https://requires.io/github/utn-frm-si/reservas/requirements.svg?branch=master)](https://requires.io/github/utn-frm-si/reservas/requirements/?branch=master)
+[![Code Climate](https://codeclimate.com/github/utn-frm-si/reservas/badges/gpa.svg)]
+    (https://codeclimate.com/github/utn-frm-si/reservas)
+[![Requirements Status](https://requires.io/github/utn-frm-si/reservas/requirements.svg?branch=master)]
+    (https://requires.io/github/utn-frm-si/reservas/requirements/?branch=master)
 
 Gestión de reservas de aulas y laboratorios


### PR DESCRIPTION
Se añade _badge_ de **Code Climate** **[1]**, que indica el puntaje obteniedo en base a revisiones automáticas de código.

**[1]** https://codeclimate.com/
