### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/app_facturacion/models/LineaTelefonica.py
+++ b/app_facturacion/models/LineaTelefonica.py
@@ -13,7 +13,7 @@ class LineaTelefonica(models.Model):
 
     # Representación del objeto
     def __str__(self):
-        return '%s' % str(self.numero)
+        return '{0!s}'.format(str(self.numero))
 
     # Información de la clase
     class Meta:

--- a/app_facturacion/models/LineaTelefonica.py
+++ b/app_facturacion/models/LineaTelefonica.py
@@ -13,7 +13,7 @@ class LineaTelefonica(models.Model):
 
     # Representación del objeto
     def __str__(self):
-        return '{0!s}'.format(str(self.numero))
+        return '{0:d}'.format(self.numero)
 
     # Información de la clase
     class Meta:

--- a/app_facturacion/models/PlanLinea.py
+++ b/app_facturacion/models/PlanLinea.py
@@ -13,7 +13,7 @@ class PlanLinea(models.Model):
 
     # Representación del objeto
     def __str__(self):
-        return '<PlanLinea>: %s' % str(self.id)
+        return '<PlanLinea>: {0!s}'.format(str(self.id))
 
     # Información de la clase
     class Meta:

--- a/app_facturacion/models/TipoConcepto.py
+++ b/app_facturacion/models/TipoConcepto.py
@@ -10,7 +10,7 @@ class TipoConcepto(models.Model):
 
     # Representación del objeto
     def __str__(self):
-        return '%s' % self.nombre
+        return '{0!s}'.format(self.nombre)
 
     # Información de la clase
     class Meta:

--- a/app_facturacion/models/TipoConceptoRegex.py
+++ b/app_facturacion/models/TipoConceptoRegex.py
@@ -11,7 +11,7 @@ class TipoConceptoRegex(models.Model):
 
     # Representación del objeto
     def __str__(self):
-        return '%s' % str(self.id)
+        return '{0!s}'.format(str(self.id))
 
     # Información de la clase
     class Meta:

--- a/app_facturacion/models/Usuario.py
+++ b/app_facturacion/models/Usuario.py
@@ -10,7 +10,7 @@ class Usuario(models.Model):
 
     # Representación del objeto
     def __str__(self):
-        return '%s, %s' % (self.apellido, self.nombre)
+        return '{0!s}, {1!s}'.format(self.apellido, self.nombre)
 
     # Información de la clase
     class Meta:

--- a/app_reservas/models/Aula.py
+++ b/app_reservas/models/Aula.py
@@ -12,7 +12,7 @@ def establecer_destino_archivo_ubicacion(instance, filename):
     # Almacena el archivo en: 'app_reservas/ubicaciones/aulas/<nombre_completo_del_aula>.<extension>'
     ruta_archivos_ubicacion = 'app_reservas/ubicaciones/aulas/'
     extension_archivo = filename.split('.')[-1] if '.' in filename else ''
-    nombre_archivo = '%s.%s' % (slugify(str(instance)), extension_archivo)
+    nombre_archivo = '{0!s}.{1!s}'.format(slugify(str(instance)), extension_archivo)
     return os.path.join(ruta_archivos_ubicacion, nombre_archivo)
 
 
@@ -28,12 +28,12 @@ class Aula(Recurso):
 
     # Representación del objeto
     def __str__(self):
-        return '%s - %s' % (self.get_nombre_corto(), self.nivel)
+        return '{0!s} - {1!s}'.format(self.get_nombre_corto(), self.nivel)
 
     def get_nombre_corto(self):
         nombre_corto = ''
         if self.nombre is None or self.nombre == '':
-            nombre_corto = 'Aula %s' % self.numero
+            nombre_corto = 'Aula {0!s}'.format(self.numero)
         else:
             nombre_corto = self.nombre
         return nombre_corto

--- a/app_reservas/models/Aula.py
+++ b/app_reservas/models/Aula.py
@@ -33,7 +33,7 @@ class Aula(Recurso):
     def get_nombre_corto(self):
         nombre_corto = ''
         if self.nombre is None or self.nombre == '':
-            nombre_corto = 'Aula {0!s}'.format(self.numero)
+            nombre_corto = 'Aula {0:d}'.format(self.numero)
         else:
             nombre_corto = self.nombre
         return nombre_corto

--- a/app_reservas/models/Cuerpo.py
+++ b/app_reservas/models/Cuerpo.py
@@ -12,7 +12,7 @@ class Cuerpo(models.Model):
         return '{0!s}'.format(self.get_nombre_corto())
 
     def get_nombre_corto(self):
-        return 'Cuerpo {0!s}'.format(self.numero)
+        return 'Cuerpo {0:d}'.format(self.numero)
 
     def get_niveles(self):
         return self.nivel_set.order_by('numero')

--- a/app_reservas/models/Cuerpo.py
+++ b/app_reservas/models/Cuerpo.py
@@ -9,10 +9,10 @@ class Cuerpo(models.Model):
 
     # Representación del objeto
     def __str__(self):
-        return '%s' % self.get_nombre_corto()
+        return '{0!s}'.format(self.get_nombre_corto())
 
     def get_nombre_corto(self):
-        return 'Cuerpo %s' % self.numero
+        return 'Cuerpo {0!s}'.format(self.numero)
 
     def get_niveles(self):
         return self.nivel_set.order_by('numero')

--- a/app_reservas/models/LaboratorioInformatico.py
+++ b/app_reservas/models/LaboratorioInformatico.py
@@ -12,7 +12,7 @@ def establecer_destino_archivo_ubicacion(instance, filename):
     # Almacena el archivo en: 'app_reservas/ubicaciones/laboratorios_informaticos/<alias_del_laboratorio_informatico>.<extension>'
     ruta_archivos_ubicacion = 'app_reservas/ubicaciones/laboratorios_informaticos/'
     extension_archivo = filename.split('.')[-1] if '.' in filename else ''
-    nombre_archivo = '%s.%s' % (slugify(instance.alias), extension_archivo)
+    nombre_archivo = '{0!s}.{1!s}'.format(slugify(instance.alias), extension_archivo)
     return os.path.join(ruta_archivos_ubicacion, nombre_archivo)
 
 
@@ -27,10 +27,10 @@ class LaboratorioInformatico(Recurso):
 
     # Representación del objeto
     def __str__(self):
-        return 'Laboratorio informático: %s' % self.nombre
+        return 'Laboratorio informático: {0!s}'.format(self.nombre)
 
     def get_nombre_corto(self):
-        return '%s (%s)' % (self.nombre, self.alias)
+        return '{0!s} ({1!s})'.format(self.nombre, self.alias)
 
     # FIXME: Método necesario para que la migración funcione correctamente.
     @staticmethod

--- a/app_reservas/models/Nivel.py
+++ b/app_reservas/models/Nivel.py
@@ -14,7 +14,7 @@ class Nivel(models.Model):
         return '{0!s} - {1!s}'.format(self.get_nombre_corto(), self.cuerpo)
 
     def get_nombre_corto(self):
-        return 'Nivel {0!s}'.format(self.numero)
+        return 'Nivel {0:d}'.format(self.numero)
 
     def get_aulas(self):
         return self.aula_set.order_by('numero', 'nombre')

--- a/app_reservas/models/Nivel.py
+++ b/app_reservas/models/Nivel.py
@@ -11,10 +11,10 @@ class Nivel(models.Model):
 
     # Representación del objeto
     def __str__(self):
-        return '%s - %s' % (self.get_nombre_corto(), self.cuerpo)
+        return '{0!s} - {1!s}'.format(self.get_nombre_corto(), self.cuerpo)
 
     def get_nombre_corto(self):
-        return 'Nivel %s' % self.numero
+        return 'Nivel {0!s}'.format(self.numero)
 
     def get_aulas(self):
         return self.aula_set.order_by('numero', 'nombre')

--- a/app_reservas/models/ProyectorMultimedia.py
+++ b/app_reservas/models/ProyectorMultimedia.py
@@ -11,10 +11,10 @@ class ProyectorMultimedia(Recurso):
 
     # Representación del objeto
     def __str__(self):
-        return 'Proyector multimedia: %s' % self.get_nombre_corto()
+        return 'Proyector multimedia: {0!s}'.format(self.get_nombre_corto())
 
     def get_nombre_corto(self):
-        return 'PM-%s' % self.identificador
+        return 'PM-{0!s}'.format(self.identificador)
 
     # Información de la clase
     class Meta:

--- a/app_reservas/models/Recurso.py
+++ b/app_reservas/models/Recurso.py
@@ -14,10 +14,10 @@ class Recurso(models.Model):
 
     # Representación del objeto
     def __str__(self):
-        return '%s' % self.get_nombre_corto()
+        return '{0!s}'.format(self.get_nombre_corto())
 
     def get_nombre_corto(self):
-        return 'Recurso: %d' % self.id
+        return 'Recurso: {0:d}'.format(self.id)
 
     def get_eventos(self):
         return obtener_eventos(self.calendar_codigo)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:utn-frm-si:reservas?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:utn-frm-si:reservas?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
