### PR TITLE
Especificación de saltos de línea en JSON de eventos de recurso

### DIFF
--- a/app_reservas/models/Recurso.py
+++ b/app_reservas/models/Recurso.py
@@ -30,7 +30,7 @@ class Recurso(models.Model):
             if primera_iteracion:
                 primera_iteracion = False
             else:
-                eventos_json += ','
+                eventos_json += ',\n'
             evento_str = json.dumps({
                 'title': evento['titulo'],
                 'start': evento['inicio_str'],


### PR DESCRIPTION
Se añade un **salto de línea entre eventos**, en el archivo JSON de eventos de los recursos, para evitar el armado del archivo con una única línea.
