### PR TITLE
Creación de vista para visualización de los cuerpos en TV

### DIFF
--- a/app_reservas/urls.py
+++ b/app_reservas/urls.py
@@ -68,4 +68,9 @@ urlpatterns = [
         views.solicitud_material_multimedia,
         name='solicitud_material_multimedia'
     ),
+    url(
+        r'^tv/cuerpos/$',
+        views.tv_cuerpos,
+        name='tv_cuerpos'
+    ),
 ]

--- a/app_reservas/views.py
+++ b/app_reservas/views.py
@@ -108,6 +108,18 @@ def cuerpo_detalle(request, num_cuerpo):
     )
 
 
+def tv_cuerpos(request):
+    # Obtiene todos los cuerpos, ordenados por número.
+    cuerpos = Cuerpo.objects.order_by('numero')
+    return render(
+        request,
+        'app_reservas/tv_cuerpos.html',
+        {
+            'cuerpos': cuerpos,
+        }
+    )
+
+
 def recurso_eventos_json(request, recurso_id):
     # Indica la ruta donde se almacenan los archivos JSON de eventos de recursos.
     ruta_archivos = 'media/app_reservas/eventos_recursos/'

--- a/templates/app_reservas/base_calendario.html
+++ b/templates/app_reservas/base_calendario.html
@@ -20,8 +20,10 @@
 
 {% block scripts %}
     <script>
+        {% block fullcalendar_js_vars %}{% endblock %}
+
         $(document).ready(function() {
-            $('#calendar').fullCalendar({
+            $({% block fullcalendar_container %}'#calendar'{% endblock %}).fullCalendar({
                 {% block fullcalendar_defaultView %}
                     defaultView: 'timelineDay',
                 {% endblock %}
@@ -41,9 +43,11 @@
                     }
                 },
                 header: {
-                    left: 'prev,next today datepickerButton',
-                    center: 'title',
-                    right: '',
+                    {% block fullcalendar_header %}
+                        left: 'prev,next today datepickerButton',
+                        center: 'title',
+                        right: '',
+                    {% endblock %}
                 },
                 viewRender: function(view, element) {
                     // Obtiene el objeto asociado al datepicker.

--- a/templates/app_reservas/base_tv.html
+++ b/templates/app_reservas/base_tv.html
@@ -1,0 +1,26 @@
+{% extends 'app_reservas/base_calendario.html' %}
+{% load static %}
+
+
+{% block fullcalendar_header %}
+    left: '',
+    center: '',
+    right: '',
+{% endblock %}
+
+
+{% block fullcalendar_js_vars %}
+    var display_hours = 5; // TODO: Parametrizar
+    var previous_hour = new Date().getHours() - 1;
+    var min_hour = Math.min(24 - display_hours, previous_hour);
+    var max_hour = min_hour + display_hours;
+
+    var min_time_string = min_hour.toString() + ':00:00';
+    var max_time_string = max_hour.toString() + ':00:00';
+{% endblock %}
+
+
+{% block fullcalendar_opciones %}
+    minTime: min_time_string,
+    maxTime: max_time_string,
+{% endblock %}

--- a/templates/app_reservas/tv_cuerpos.html
+++ b/templates/app_reservas/tv_cuerpos.html
@@ -1,0 +1,113 @@
+{% extends 'app_reservas/base_tv.html' %}
+{% load static %}
+
+{% block title %}
+    Distribución física - Cuerpos
+{% endblock title %}
+
+
+{% block contenido %}
+    {% for cuerpo in cuerpos %}
+        <h2 style="text-align: center;">{{ cuerpo.get_nombre_corto }}</h2>
+
+        <div id="calendar_cuerpo_{{ cuerpo.numero }}" class="calendar"></div>
+
+        <br/>
+        <br/>
+    {% endfor %}
+{% endblock contenido %}
+
+
+{% block fullcalendar_container %}
+    '.calendar'
+{% endblock fullcalendar_container %}
+
+
+{% block fullcalendar_resources %}
+    resourceColumns: [
+        {
+            group: true,
+            labelText: 'Nivel',
+            field: 'nivel'
+        },
+        {
+            labelText: 'Recurso',
+            field: 'title'
+        },
+    ],
+    resources: [
+        {% for cuerpo in cuerpos %}
+            {% for nivel in cuerpo.get_niveles %}
+                {% for aula in nivel.get_aulas %}
+                    {
+                        id: '{{ aula.id }}',
+                        nivel: '{{ nivel.get_nombre_corto }}',
+                        title: '{{ aula.get_nombre_corto }}',
+                    },
+                {% endfor %}
+                {% for laboratorio in nivel.get_laboratorios_informaticos %}
+                    {
+                        id: '{{ laboratorio.id }}',
+                        nivel: '{{ nivel.get_nombre_corto }}',
+                        title: '{{ laboratorio.get_nombre_corto }}',
+                    },
+                {% endfor %}
+            {% endfor %}
+        {% endfor %}
+    ],
+{% endblock fullcalendar_resources %}
+
+
+{% block fullcalendar_eventSources %}
+    {% for cuerpo in cuerpos %}
+        {% for nivel in cuerpo.get_niveles %}
+            {% for aula in nivel.get_aulas %}
+                {
+                    url: '{% url "recurso_eventos_json" aula.id %}',
+                    {% if aula.calendar_color %}
+                        color: '{{ aula.calendar_color }}',
+                    {% endif %}
+                },
+            {% endfor %}
+            {% for laboratorio in nivel.get_laboratorios_informaticos %}
+                {
+                    url: '{% url "recurso_eventos_json" laboratorio.id %}',
+                    {% if laboratorio.calendar_color %}
+                        color: '{{ laboratorio.calendar_color }}',
+                    {% endif %}
+                },
+            {% endfor %}
+        {% endfor %}
+    {% endfor %}
+{% endblock fullcalendar_eventSources %}
+
+
+{% block scripts %}
+    {{ block.super }}
+
+    <script>
+        $(document).ready(function() {
+            // Quita de cada calendario los recursos correspondientes a un cuerpo distinto.
+            $('.calendar').each(function () {
+                // Obtiene el ID del calendario.
+                var calendar_id = $(this).attr('id');
+                // Remueve del calendario los recursos que no pertenecen al calendario del cuerpo
+                // actual.
+                {% for cuerpo in cuerpos %}
+                    {% for nivel in cuerpo.get_niveles %}
+                        {% for recurso in nivel.get_aulas %}
+                            if (calendar_id != 'calendar_cuerpo_{{ cuerpo.numero }}') {
+                                $(this).fullCalendar('removeResource', {{ recurso.id }});
+                            }
+                        {% endfor %}
+                        {% for recurso in nivel.get_laboratorios_informaticos %}
+                            if (calendar_id != 'calendar_cuerpo_{{ cuerpo.numero }}') {
+                                $(this).fullCalendar('removeResource', {{ recurso.id }});
+                            }
+                        {% endfor %}
+                    {% endfor %}
+                {% endfor %}
+            });
+        });
+    </script>
+{% endblock scripts %}


### PR DESCRIPTION
Se añade una **vista para TV**, que lista todos los **cuerpos**, con un calendario propio de cada uno, conteniendo sus recursos.

Todos los calendarios se crean conteniendo todos los recursos, y posteriormente se quitan de cada calendario aquellos recursos que no pertenecen al cuerpo, mediante el método **`fullCalendar('removeResource', id)`** **[1]**.

**[1]** http://fullcalendar.io/docs/resource_data/removeResource/
