### PR TITLE
Creación de 'block' para callback 'loading' de FullCalendar

### DIFF
--- a/templates/app_reservas/base_calendario.html
+++ b/templates/app_reservas/base_calendario.html
@@ -69,15 +69,17 @@
                         datepicker.datepicker('setUTCDate', momentoFullcalendar.toDate());
                     }
                 },
-                loading: function(isLoading, view) {
-                    if (isLoading) {
-                        loadingSpinner = $('<i id="calendar_loading_indicator" class="fa fa-2x fa-spinner fa-spin"></i>');
-                        $('.fc-left').append(loadingSpinner);
-                    }
-                    else {
-                        $('#calendar_loading_indicator').remove();
-                    }
-                },
+                {% block fullcalendar_loading_callback %}
+                    loading: function(isLoading, view) {
+                        if (isLoading) {
+                            loadingSpinner = $('<i id="calendar_loading_indicator" class="fa fa-2x fa-spinner fa-spin"></i>');
+                            $('.fc-left').append(loadingSpinner);
+                        }
+                        else {
+                            $('#calendar_loading_indicator').remove();
+                        }
+                    },
+                {% endblock fullcalendar_loading_callback %}
                 {% block fullcalendar_opciones %}{% endblock %}
             });
 

--- a/templates/app_reservas/tv_cuerpos.html
+++ b/templates/app_reservas/tv_cuerpos.html
@@ -82,6 +82,10 @@
 {% endblock fullcalendar_eventSources %}
 
 
+{% block fullcalendar_loading_callback %}
+{% endblock fullcalendar_loading_callback %}
+
+
 {% block scripts %}
     {{ block.super }}
 


### PR DESCRIPTION
Se crea un **bloque** para contener el _callback_ `loading` de FullCalendar, y así poder sobrescribirlo en la vista de cuerpos de TV.
