### PR TITLE
Creación de vista para visualización de área específica en TV

### DIFF
--- a/app_reservas/urls.py
+++ b/app_reservas/urls.py
@@ -14,6 +14,7 @@ from .views import (
     SolicitudAulaView,
     SolicitudLaboratorioInformaticoView,
     SolicitudMaterialMultimediaView,
+    TvAreaDetailView,
     TvCuerposListView,
 )
 
@@ -88,5 +89,10 @@ urlpatterns = [
         r'^tv/cuerpos/$',
         TvCuerposListView.as_view(),
         name='tv_cuerpos'
+    ),
+    url(
+        r'^tv/area/(?P<slug>[-\w]+)/$',
+        TvAreaDetailView.as_view(),
+        name='tv_area'
     ),
 ]

--- a/app_reservas/views/__init__.py
+++ b/app_reservas/views/__init__.py
@@ -17,4 +17,7 @@ from .solicitud import (
     SolicitudLaboratorioInformaticoView,
     SolicitudMaterialMultimediaView,
 )
-from .tv import TvCuerposListView
+from .tv import (
+    TvAreaDetailView,
+    TvCuerposListView,
+)

--- a/app_reservas/views/tv.py
+++ b/app_reservas/views/tv.py
@@ -1,8 +1,21 @@
 # coding=utf-8
 
+from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 
-from app_reservas.models import Cuerpo
+from app_reservas.models import (
+    Area,
+    Cuerpo,
+)
+
+
+class TvAreaDetailView(DetailView):
+    """
+    Vista de detalle para la visualización en TV de una instancia específica de Area.
+    """
+    model = Area
+    context_object_name = 'area'
+    template_name = 'app_reservas/tv_area.html'
 
 
 class TvCuerposListView(ListView):

--- a/templates/app_reservas/base_tv.html
+++ b/templates/app_reservas/base_tv.html
@@ -23,6 +23,10 @@
 {% endblock fullcalendar_js_vars %}
 
 
+{% block fullcalendar_loading_callback %}
+{% endblock fullcalendar_loading_callback %}
+
+
 {% block fullcalendar_opciones %}
     minTime: min_time_string,
     maxTime: max_time_string,

--- a/templates/app_reservas/tv_area.html
+++ b/templates/app_reservas/tv_area.html
@@ -1,0 +1,38 @@
+{% extends 'app_reservas/base_tv.html' %}
+{% load static %}
+
+{% block title %}
+    Área: {{ area }}
+{% endblock title %}
+
+
+{% block contenido %}
+    <h1 style="text-align: center;">{{ area }}</h1>
+
+    <div id="calendar"></div>
+{% endblock contenido %}
+
+
+{% block fullcalendar_resources %}
+    resourceLabelText: 'Aula',
+    resources: [
+        {% for aula in area.get_aulas %}
+            {
+                id: '{{ aula.id }}',
+                title: '{{ aula }}',
+            },
+        {% endfor %}
+    ],
+{% endblock fullcalendar_resources %}
+
+
+{% block fullcalendar_eventSources %}
+    {% for aula in area.get_aulas %}
+        {
+            url: '{% url "recurso_eventos_json" aula.id %}',
+            {% if aula.calendar_color %}
+                color: '{{ aula.calendar_color }}',
+            {% endif %}
+        },
+    {% endfor %}
+{% endblock fullcalendar_eventSources %}

--- a/templates/app_reservas/tv_cuerpos.html
+++ b/templates/app_reservas/tv_cuerpos.html
@@ -82,10 +82,6 @@
 {% endblock fullcalendar_eventSources %}
 
 
-{% block fullcalendar_loading_callback %}
-{% endblock fullcalendar_loading_callback %}
-
-
 {% block scripts %}
     {{ block.super }}
 


### PR DESCRIPTION
Se añade una vista para la **visualización de un área específica en TV**, cuya URL está formada de la siguiente manera: `/tv/area/<slug>/`.
