### PR TITLE
Utilización de imports relativos explícitos

### DIFF
--- a/app_facturacion/admin.py
+++ b/app_facturacion/admin.py
@@ -1,6 +1,14 @@
 from django.contrib import admin
 
-from .models import Area, LineaTelefonica, PlanLinea, TipoConcepto, TipoConceptoRegex, Usuario
+from .models import (
+    Area,
+    LineaTelefonica,
+    PlanLinea,
+    TipoConcepto,
+    TipoConceptoRegex,
+    Usuario,
+)
+
 
 admin.site.register(Area)
 admin.site.register(LineaTelefonica)

--- a/app_facturacion/models/__init__.py
+++ b/app_facturacion/models/__init__.py
@@ -5,6 +5,7 @@ from .TipoConcepto import TipoConcepto
 from .TipoConceptoRegex import TipoConceptoRegex
 from .Usuario import Usuario
 
+
 __all__ = [
     'Area',
     'LineaTelefonica',

--- a/app_facturacion/urls.py
+++ b/app_facturacion/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 
 from . import views
 
+
 urlpatterns = [
     url(
         r'^$',

--- a/app_facturacion/views.py
+++ b/app_facturacion/views.py
@@ -5,7 +5,7 @@ from io import TextIOWrapper
 
 from django.shortcuts import render
 
-from app_facturacion.models import Usuario
+from .models import Usuario
 
 
 def index(request):

--- a/app_reservas/admin.py
+++ b/app_reservas/admin.py
@@ -1,6 +1,13 @@
 from django.contrib import admin
 
-from .models import Area, Aula, Cuerpo, LaboratorioInformatico, Nivel, ProyectorMultimedia
+from .models import (
+    Area,
+    Aula,
+    Cuerpo,
+    LaboratorioInformatico,
+    Nivel,
+    ProyectorMultimedia,
+)
 
 
 admin.site.register(Area)

--- a/app_reservas/apps.py
+++ b/app_reservas/apps.py
@@ -6,4 +6,4 @@ class ReservasConfig(AppConfig):
     verbose_name = 'Reservas'
 
     def ready(self):
-        import app_reservas.signals.recurso
+        from .signals import recurso

--- a/app_reservas/migrations/0008_directorio_archivo_ubicacion_aula.py
+++ b/app_reservas/migrations/0008_directorio_archivo_ubicacion_aula.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-import app_reservas.models.Aula
+from ..models import Aula
 
 
 class Migration(migrations.Migration):
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='aula',
             name='archivo_ubicacion',
-            field=models.FileField(blank=True, upload_to=app_reservas.models.Aula.establecer_destino_archivo_ubicacion),
+            field=models.FileField(blank=True, upload_to=Aula.establecer_destino_archivo_ubicacion),
         ),
     ]

--- a/app_reservas/migrations/0010_archivo_ubicacion_laboratorio_informatico.py
+++ b/app_reservas/migrations/0010_archivo_ubicacion_laboratorio_informatico.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-import app_reservas.models.LaboratorioInformatico
+from ..models import LaboratorioInformatico
 
 
 class Migration(migrations.Migration):
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='laboratorioinformatico',
             name='archivo_ubicacion',
-            field=models.FileField(upload_to=app_reservas.models.LaboratorioInformatico.establecer_destino_archivo_ubicacion, blank=True),
+            field=models.FileField(upload_to=LaboratorioInformatico.establecer_destino_archivo_ubicacion, blank=True),
         ),
     ]

--- a/app_reservas/models/Recurso.py
+++ b/app_reservas/models/Recurso.py
@@ -4,7 +4,7 @@ import json
 
 from django.db import models
 
-from app_reservas.adapters.google_calendar import obtener_eventos
+from ..adapters.google_calendar import obtener_eventos
 
 
 class Recurso(models.Model):

--- a/app_reservas/models/__init__.py
+++ b/app_reservas/models/__init__.py
@@ -6,6 +6,7 @@ from .Nivel import Nivel
 from .ProyectorMultimedia import ProyectorMultimedia
 from .Recurso import Recurso
 
+
 __all__ = [
     'Area',
     'Aula',

--- a/app_reservas/signals/recurso.py
+++ b/app_reservas/signals/recurso.py
@@ -1,7 +1,7 @@
 from django.db.models.signals import post_save
 
-from app_reservas.models import Recurso
-from app_reservas.tasks import obtener_eventos_recurso_especifico
+from ..models import Recurso
+from ..tasks import obtener_eventos_recurso_especifico
 
 
 def obtener_eventos(sender, instance, created, **kwargs):

--- a/app_reservas/tasks.py
+++ b/app_reservas/tasks.py
@@ -1,5 +1,8 @@
 import os
-from celery import group, shared_task
+from celery import (
+    group,
+    shared_task,
+)
 
 from .models import Recurso
 

--- a/app_reservas/templatetags/navbar_tags.py
+++ b/app_reservas/templatetags/navbar_tags.py
@@ -1,6 +1,10 @@
 from django import template
 
-from app_reservas.models import Area, Cuerpo
+from ..models import (
+    Area,
+    Cuerpo,
+)
+
 
 register = template.Library()
 

--- a/app_reservas/views/area.py
+++ b/app_reservas/views/area.py
@@ -2,7 +2,7 @@
 
 from django.views.generic.detail import DetailView
 
-from app_reservas.models import Area
+from ..models import Area
 
 
 class AreaDetailView(DetailView):

--- a/app_reservas/views/aula.py
+++ b/app_reservas/views/aula.py
@@ -2,7 +2,7 @@
 
 from django.views.generic.detail import DetailView
 
-from app_reservas.models import Aula
+from ..models import Aula
 
 
 class AulaDetailView(DetailView):

--- a/app_reservas/views/cuerpo.py
+++ b/app_reservas/views/cuerpo.py
@@ -3,7 +3,7 @@
 from django.shortcuts import get_object_or_404
 from django.views.generic.detail import DetailView
 
-from app_reservas.models import Cuerpo
+from ..models import Cuerpo
 
 
 class CuerpoDetailView(DetailView):

--- a/app_reservas/views/laboratorio_informatico.py
+++ b/app_reservas/views/laboratorio_informatico.py
@@ -4,7 +4,7 @@ from django.shortcuts import get_object_or_404
 from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 
-from app_reservas.models import LaboratorioInformatico
+from ..models import LaboratorioInformatico
 
 
 class LaboratorioInformaticoDetailView(DetailView):

--- a/app_reservas/views/nivel.py
+++ b/app_reservas/views/nivel.py
@@ -3,7 +3,7 @@
 from django.shortcuts import get_object_or_404
 from django.views.generic.detail import DetailView
 
-from app_reservas.models import Cuerpo, Nivel
+from ..models import Cuerpo, Nivel
 
 
 class NivelDetailView(DetailView):

--- a/app_reservas/views/proyector_multimedia.py
+++ b/app_reservas/views/proyector_multimedia.py
@@ -4,7 +4,7 @@ from django.shortcuts import get_object_or_404
 from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 
-from app_reservas.models import ProyectorMultimedia
+from ..models import ProyectorMultimedia
 
 
 class ProyectorMultimediaDetailView(DetailView):

--- a/app_reservas/views/recurso.py
+++ b/app_reservas/views/recurso.py
@@ -6,7 +6,7 @@ from dateutil.parser import parse
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 
-from app_reservas.models import Recurso
+from ..models import Recurso
 
 
 def recurso_eventos_json(request, pk):

--- a/app_reservas/views/tv.py
+++ b/app_reservas/views/tv.py
@@ -3,7 +3,7 @@
 from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 
-from app_reservas.models import (
+from ..models import (
     Area,
     Cuerpo,
 )

--- a/reservas/settings/heroku.py
+++ b/reservas/settings/heroku.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
-import dj_database_url
+from dj_database_url import config
 
 from .production import *
 
-DATABASES['default'] = dj_database_url.config()
+DATABASES['default'] = config()

--- a/reservas/settings/production.py
+++ b/reservas/settings/production.py
@@ -1,7 +1,5 @@
 # coding=utf-8
 
-import dj_database_url
-
 from .base import *
 
 DEBUG = False


### PR DESCRIPTION
Se hace uso de **_imports_ relativos explícitos**, para facilitar la reutilización y renombrado de aplicaciones. Además, se hace limpieza de algunos _imports_.
