### PR TITLE
Inclusión en gitignore de directorio 'media' y archivos de Celery Beat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,16 @@
 # Directorio de componentes instalados por Django-Bower.
 /components
 
+# Directorio de media.
+/media
+
 # Variables de entorno utilizadas por Docker.
 environment.txt
+
+# Archivos temporales de Celery Beat.
+celerybeat*.bak
+celerybeat*.dat
+celerybeat*.dir
 
 ##########
 # Python #


### PR DESCRIPTION
Se añaden al **gitignore** reglas para el directorio `/media` y los archivos temporales generados por **Celery Beat**.
