### PR TITLE
Corrección en la obtención de eventos cuando no hay conexión

### DIFF
--- a/app_reservas/models/Recurso.py
+++ b/app_reservas/models/Recurso.py
@@ -4,7 +4,7 @@ import json
 
 from django.db import models
 
-from ..adapters.google_calendar import obtener_eventos
+from ..adapters.google_calendar import generar_lista_eventos
 
 
 class Recurso(models.Model):
@@ -20,7 +20,7 @@ class Recurso(models.Model):
         return 'Recurso: {0:d}'.format(self.id)
 
     def get_eventos(self):
-        return obtener_eventos(self.calendar_codigo)
+        return generar_lista_eventos(self.calendar_codigo)
 
     def get_eventos_json(self):
         eventos = self.get_eventos()


### PR DESCRIPTION
Se corrige el funcionamiento en la **obtención de eventos de un recurso** desde Google Calendar, para que no se sobrescriba el archivo de eventos con un listado vacío, cuando hay problemas de conexión.

Hasta el momento, si se producía algún problema de conexión, se generaba una excepción `httplib2.ServerNotFound` y el archivo JSON de eventos del recurso se sobrescribía con el contenido **`[]`**, perdiendo así la información actual de eventos.
