### PR TITLE
Personalización de paleta de colores para vistas de TV

### DIFF
--- a/app_reservas/tasks.py
+++ b/app_reservas/tasks.py
@@ -38,7 +38,7 @@ def obtener_eventos_recurso_especifico(recurso, ruta_archivos='media/app_reserva
 
     # Verifica que se hayan obtenido eventos, ya que en caso de no obtenerse por algún problema de
     # conexión, no debe sobrescribirse el archivo de eventos del recurso.
-    if len(json.loads(eventos)) > 0:
+    if json.loads(eventos):
         # Crea o sobrescribe el archivo del recurso actual.
         with open(nombre_archivo_completo, 'w') as archivo:
             # Escribe en el archivo los eventos del recurso, en formato JSON.

--- a/static/apps/reservas/css/tv.css
+++ b/static/apps/reservas/css/tv.css
@@ -1,0 +1,23 @@
+/* Cuerpo de página */
+body {
+    /* Color de fondo de la página: Dark Gray */
+    background-color: #A9A9A9;
+    /* Color del texto de la página: Blanco */
+    color: white;
+}
+
+/* Calendarios */
+div.fc-view-container {
+    /* Color de fondo de los calendarios: Steel Blue */
+    background-color: #4682B4;
+}
+
+/* Eventos de calendario */
+.fc-event {
+    /* Tamaño normal de la fuente de los eventos */
+    font-size: 1em;
+    /* Fuente de los eventos en negrita */
+    font-weight: bold;
+    /* Fuente de los eventos sin subrayado */
+    text-decoration: none !important;
+}

--- a/templates/app_reservas/base_tv.html
+++ b/templates/app_reservas/base_tv.html
@@ -5,6 +5,12 @@
 {% block header %}
 {% endblock header %}
 
+
+{% block static_css %}
+    <link rel="stylesheet" href='{% static 'apps/reservas/css/tv.css' %}'>
+{% endblock static_css %}
+
+
 {% block fullcalendar_header %}
     left: '',
     center: '',
@@ -30,4 +36,6 @@
 {% block fullcalendar_opciones %}
     minTime: min_time_string,
     maxTime: max_time_string,
+    eventBackgroundColor: '#087830',
+    eventBorderColor: '#4CBB17',
 {% endblock fullcalendar_opciones %}


### PR DESCRIPTION
Se modifica la **paleta de colores para las vistas de TV**. En el caso del color por defecto de los eventos, se utiliza **La Salle Green** para el borde **[1]** y **Kelly Green** para el fondo **[2]**.

**[1]** http://fullcalendar.io/docs/event_rendering/eventBorderColor/
**[2]** http://fullcalendar.io/docs/event_rendering/eventBackgroundColor/
