### PR TITLE
Correcciones en estilos para vistas de TV

### DIFF
--- a/templates/app_reservas/base_tv.html
+++ b/templates/app_reservas/base_tv.html
@@ -16,6 +16,8 @@
 
 
 {% block static_css %}
+    {{ block.super }}
+
     <link rel="stylesheet" href='{% static 'apps/reservas/css/tv.css' %}'>
 {% endblock static_css %}
 
@@ -45,6 +47,6 @@
 {% block fullcalendar_opciones %}
     minTime: min_time_string,
     maxTime: max_time_string,
-    eventBackgroundColor: '#087830',
-    eventBorderColor: '#4CBB17',
+    eventBackgroundColor: '#4CBB17',
+    eventBorderColor: '#087830',
 {% endblock fullcalendar_opciones %}


### PR DESCRIPTION
Se corrige la **carga de CSS** en la vista de TV, y los **colores de los eventos**, que habían sido especificados en forma inversa a como se detalló en el PR #135.
