### PR TITLE
Uso de 'container-fluid' para el aprovechamiento del ancho de página

### DIFF
--- a/templates/app_facturacion/base.html
+++ b/templates/app_facturacion/base.html
@@ -29,11 +29,11 @@
 
 <body>
 
-<div class="container">
+<div class="container-fluid">
 
     {% block contenido %}{% endblock %}
 
-</div> <!-- /container -->
+</div> <!-- /container-fluid -->
 
 
 <!-- Bootstrap core JavaScript

--- a/templates/app_reservas/base.html
+++ b/templates/app_reservas/base.html
@@ -40,11 +40,11 @@
     {% obtener_informacion_navbar %}
 {% endblock header %}
 
-<div class="container">
+<div class="container-fluid">
 
     {% block contenido %}{% endblock %}
 
-</div> <!-- /container -->
+</div> <!-- /container-fluid -->
 
 
 <!-- Bootstrap core JavaScript

--- a/templates/app_reservas/navbar.html
+++ b/templates/app_reservas/navbar.html
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-default">
-    <div class="container">
+    <div class="container-fluid">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
                 <span class="sr-only">Toggle navigation</span>


### PR DESCRIPTION
Se modifica la clase CSS de los contenedores, de `container` a `container-fluid` **[1]**, para **aprovechar el ancho de página** y reducir los márgenes laterales.

**[1]** https://getbootstrap.com/css/#overview-container
