### PR TITLE
Implementación de transición entre cuerpos para vista de TV

### DIFF
--- a/templates/app_reservas/tv_cuerpos.html
+++ b/templates/app_reservas/tv_cuerpos.html
@@ -7,14 +7,18 @@
 
 
 {% block contenido %}
-    {% for cuerpo in cuerpos %}
-        <h2 style="text-align: center;">{{ cuerpo.get_nombre_corto }}</h2>
+    <div id="cuerpos">
+        {% for cuerpo in cuerpos %}
+            <div id="div{{ forloop.counter }}" class="display">
+                <h2 style="text-align: center;">{{ cuerpo.get_nombre_corto }}</h2>
 
-        <div id="calendar_cuerpo_{{ cuerpo.numero }}" class="calendar"></div>
+                <div id="calendar_cuerpo_{{ cuerpo.numero }}" class="calendar"></div>
 
-        <br/>
-        <br/>
-    {% endfor %}
+                <br/>
+                <br/>
+            </div>
+        {% endfor %}
+    </div>
 {% endblock contenido %}
 
 
@@ -97,6 +101,27 @@
                     {% endblock %}
                 });
             {% endfor %}
+        });
+
+        $(document).ready(function() {
+            // Función que genera la transición de cuerpos, al ir mostrando un cuerpo a la vez, y
+            // ocultando los cuerpos restantes.
+            function generarTransicionCuerpo() {
+                $('div.display','#cuerpos')
+                        .stop()
+                        .hide()
+                        .filter( function() { return this.id == ('div' + counter); })
+                        .show('slow');
+                counter == {{ cuerpos|length }} ? counter = 1 : counter++;
+            }
+
+            // Ejecuta la transición sólo cuando hay más de un cuerpo disponible en la vista.
+            if ({{ cuerpos|length }} > 1) {
+                var counter = 1;
+                generarTransicionCuerpo();
+                // Establece la transición entre cuerpos cada 10 segundos.
+                var timer = setInterval(generarTransicionCuerpo, 10000);
+            }
         });
     </script>
 {% endblock scripts %}


### PR DESCRIPTION
Se añade la función de **transición enre cuerpos** para la vista de TV de cuerpos. Esta funcionalidad permite que se muestren los cuerpos en forma individual, y que la transición entre un cuerpo y otro sea cada 10 segundos.
