### PR TITLE
Creación de campo 'nombre' en modelo Cuerpo

### DIFF
--- a/app_reservas/admin/cuerpo.py
+++ b/app_reservas/admin/cuerpo.py
@@ -12,6 +12,7 @@ class CuerpoAdmin(admin.ModelAdmin):
     """
     list_display = (
         'numero',
+        'nombre',
         '_niveles',
     )
 

--- a/app_reservas/migrations/0017_cuerpo_nombre.py
+++ b/app_reservas/migrations/0017_cuerpo_nombre.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """
+    Creación de campo 'nombre' en Cuerpo.
+    """
+
+    dependencies = [
+        ('app_reservas', '0016_bedelia_laboratorio_electronica'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cuerpo',
+            name='nombre',
+            field=models.CharField(blank=True, max_length=50),
+        ),
+    ]

--- a/app_reservas/models/cuerpo.py
+++ b/app_reservas/models/cuerpo.py
@@ -5,6 +5,7 @@ from django.db import models
 
 class Cuerpo(models.Model):
     # Atributos
+    nombre = models.CharField(max_length=50, blank=True)
     numero = models.PositiveSmallIntegerField()
 
     class Meta:
@@ -20,7 +21,12 @@ class Cuerpo(models.Model):
         """
         Representación de la instancia.
         """
-        return '{0!s}'.format(self.get_nombre_corto())
+        if self.nombre:
+            s = '{0!s}: {1!s}'.format(self.get_nombre_corto(),
+                                      self.nombre)
+        else:
+            s = '{0!s}'.format(self.get_nombre_corto())
+        return s
 
     def get_nombre_corto(self):
         """

--- a/app_reservas/models/nivel.py
+++ b/app_reservas/models/nivel.py
@@ -23,7 +23,8 @@ class Nivel(models.Model):
         """
         Representación de la instancia.
         """
-        return '{0!s} - {1!s}'.format(self.get_nombre_corto(), self.cuerpo)
+        return '{0!s} - {1!s}'.format(self.get_nombre_corto(),
+                                      self.cuerpo.get_nombre_corto())
 
     def get_nombre_corto(self):
         """

--- a/templates/app_reservas/cuerpo_detail.html
+++ b/templates/app_reservas/cuerpo_detail.html
@@ -2,12 +2,12 @@
 {% load static %}
 
 {% block title %}
-    {{ cuerpo.get_nombre_corto }}
+    {{ cuerpo }}
 {% endblock title %}
 
 
 {% block contenido %}
-    <h1 style="text-align: center;">{{ cuerpo.get_nombre_corto }}</h1>
+    <h1 style="text-align: center;">{{ cuerpo }}</h1>
 
     <br />
     <br />

--- a/templates/app_reservas/nivel_detail.html
+++ b/templates/app_reservas/nivel_detail.html
@@ -8,7 +8,7 @@
 
 {% block contenido %}
     <h1 style="text-align: center;">{{ nivel.get_nombre_corto }}</h1>
-    <h3 style="text-align: center;">{{ nivel.cuerpo.get_nombre_corto }}</h3>
+    <h3 style="text-align: center;">{{ nivel.cuerpo }}</h3>
 
     <br/>
     <br/>

--- a/templates/app_reservas/tv_cuerpos.html
+++ b/templates/app_reservas/tv_cuerpos.html
@@ -10,7 +10,7 @@
     <div id="cuerpos">
         {% for cuerpo in cuerpos %}
             <div id="cuerpo_{{ cuerpo.numero }}" class="cuerpo" data-calendario-numero="{{ forloop.counter }}">
-                <h2 style="text-align: center;">{{ cuerpo.get_nombre_corto }}</h2>
+                <h2 style="text-align: center;">{{ cuerpo }}</h2>
 
                 <div id="calendar_cuerpo_{{ cuerpo.numero }}" class="calendar"></div>
             </div>


### PR DESCRIPTION
Se añade el campo `nombre` (no obligatorio) a **Cuerpo**, y se modifican las plantillas que requieren hacer uso del nombre corto del cuerpo en vez del nuevo nombre completo.
