### PR TITLE
Actualización de Django a 1.8.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8.8
+Django==1.8.11
 amqp==1.4.8
 anyjson==0.3.3
 billiard==3.3.0.22


### PR DESCRIPTION
Se actualiza **Django** a la última revisión actual de `1.8`, para obtener los arreglos a _bugs_ de seguridad.
