### PR TITLE
Deshabilitación de scroll vertical en vistas de TV

### DIFF
--- a/static/apps/reservas/css/tv.css
+++ b/static/apps/reservas/css/tv.css
@@ -4,6 +4,8 @@ body {
     background-color: #A9A9A9;
     /* Color del texto de la página: Blanco */
     color: white;
+    /* Deshabilitación de scroll vertical */
+    overflow-y: hidden;
 }
 
 /* Cuerpos */


### PR DESCRIPTION
Se quita el **scroll vertical** en las vistas de TV. Esto también oculta la barra lateral de scroll.
