### PR TITLE
Implementación de tooltips para eventos de FullCalendar, mediante qTip

### DIFF
--- a/reservas/settings/base.py
+++ b/reservas/settings/base.py
@@ -155,6 +155,7 @@ BOWER_INSTALLED_APPS = (
     'handsontable',
     'jquery',
     'pace',
+    'qtip2',
 )
 
 # Token de Google Calendar, utilizado para consultar la información de eventos

--- a/templates/app_reservas/base_calendario.html
+++ b/templates/app_reservas/base_calendario.html
@@ -5,6 +5,7 @@
     <link rel='stylesheet' href='{% static 'fullcalendar/dist/fullcalendar.min.css' %}' />
     <link rel='stylesheet' href='{% static 'fullcalendar-scheduler/dist/scheduler.min.css' %}' />
     <link rel="stylesheet" href='{% static 'bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css' %}' />
+    <link rel="stylesheet" href='{% static 'qtip2/jquery.qtip.min.css' %}' />
     <link rel="stylesheet" href='{% static 'apps/reservas/css/base_calendario.css' %}' />
 {% endblock static_css %}
 
@@ -16,12 +17,36 @@
     <script src='{% static 'fullcalendar-scheduler/dist/scheduler.min.js' %}'></script>
     <script src='{% static 'bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js' %}'></script>
     <script src='{% static 'bootstrap-datepicker/dist/locales/bootstrap-datepicker.es.min.js' %}'></script>
+    <script src='{% static 'qtip2/jquery.qtip.min.js' %}'></script>
 {% endblock static_js_body %}
 
 
 {% block scripts %}
     <script>
-        {% block fullcalendar_js_vars %}{% endblock %}
+        {% block fullcalendar_js_vars %}
+            var tooltip = $('<div />').qtip({
+                id: 'fullcalendar',
+                prerender: true,
+                content: {
+                    text: '',
+                    title: {
+                        button: true
+                    }
+                },
+                position: {
+                    my: 'bottom center',
+                    at: 'top center',
+                    target: 'event',
+                    adjust: {
+                        mouse: false,
+                        scroll: false
+                    }
+                },
+                show: false,
+                hide: false,
+                style: 'qtip-blue qtip-rounded qtip-shadow'
+            }).qtip('api');
+        {% endblock fullcalendar_js_vars %}
 
         $(document).ready(function() {
             $({% block fullcalendar_container %}'#calendar'{% endblock %}).fullCalendar({
@@ -52,6 +77,24 @@
                         right: '',
                     {% endblock fullcalendar_header %}
                 },
+                eventClick: function(event, jsEvent, view) {
+                    {% block fullcalendar_eventClick_callback %}
+                        var title = '<h5><b>' + event.title + '</b></h5>';
+                        var content = '<b>Inicio</b>: ' + moment(event.start).format("dddd, LL, H:mm") +
+                            '<br />' + '<b>Fin</b>: ' + moment(event.end).format("dddd, LL, H:mm");
+
+                        tooltip.set({
+                            'content.title': title,
+                            'content.text': content
+                        })
+                            .reposition(jsEvent).show(jsEvent);
+                    {% endblock fullcalendar_eventClick_callback %}
+                },
+                dayClick: function(date, jsEvent, view) {
+                    {% block fullcalendar_dayClick_callback %}
+                        tooltip.hide();
+                    {% endblock fullcalendar_dayClick_callback %}
+                },
                 viewRender: function(view, element) {
                     // Obtiene el objeto asociado al datepicker.
                     var datepicker = $('.fc-datepickerButton-button');
@@ -71,6 +114,8 @@
                     if (! momentoFullcalendar.isSame(momentoDatepicker, 'day')) {
                         datepicker.datepicker('setUTCDate', momentoFullcalendar.toDate());
                     }
+
+                    tooltip.hide();
                 },
                 {% block fullcalendar_loading_callback %}
                     loading: function(isLoading, view) {

--- a/templates/app_reservas/base_tv.html
+++ b/templates/app_reservas/base_tv.html
@@ -30,6 +30,8 @@
 
 
 {% block fullcalendar_js_vars %}
+    {{ block.super }}
+
     var display_hours = 5; // TODO: Parametrizar
     var previous_hour = new Date().getHours() - 1;
 


### PR DESCRIPTION
Se añaden _tooltips_ para los eventos de los calendarios, haciendo uso de **qTip** **[1]**. Para esto, se utiliza la implementación _demo_ del sitio oficial **[2]** **[3]**.

Para transformar las fechas _epoch_ retornadas por FullCalendar, se hace uso de **Moment.js** **[4]**. Además, se quita la especificación de la opción **_viewport_** debido a problemas con la ubicación de los _tooltips_ **[5]**.

**[1]** http://qtip2.com/
**[2]** http://qtip2.com/demos
**[3]** https://jsfiddle.net/qTip2/N78hs/
**[4]** http://momentjs.com/docs/#/displaying/format/
**[5]** https://github.com/qTip2/qTip2/issues/618
