### PR TITLE
Configuración de crontab para evitar cuelgues de Celery

### DIFF
--- a/server_config/crontab
+++ b/server_config/crontab
@@ -1,0 +1,5 @@
+# Ubicar el archivo en /etc/cron.d/
+
+# Reinicia el contenedor de Celery todos los días a las 2 AM, para evitar que
+# se cuelgue el servicio de AMQP.
+0  2  *  *  *  root    docker restart reservas_celery_1


### PR DESCRIPTION
Se añade un archivo `crontab` que reinicie el servicio de **Celery** diariamente, para evitar cuelgues en el servicio de AMQP. Esto es debido a que, luego de unos días de funcionamiento continuo, Celery deja de procesar las peticiones.
