### PR TITLE
Configuración de VirtualHost de Apache

### DIFF
--- a/server_config/virtualhost.conf
+++ b/server_config/virtualhost.conf
@@ -1,0 +1,17 @@
+# Ubicar el archivo en /etc/httpd/conf.d/
+
+# Configura un VirtualHost para que todas las peticiones direccionadas a
+# /reservas sean redirigidas a la aplicación de reservas. Específicamente,
+# al contenedor Docker de Django.
+<VirtualHost *:*>
+    ProxyPreserveHost On
+    ProxyPass /reservas/ http://localhost:8000/reservas/
+    ProxyPassReverse /reservas/ http://localhost:8000/reservas/
+    ServerName gt.frm.utn.edu.ar
+
+    ProxyPass /reservas/static/ !
+    Alias /reservas/static "/opt/repos/reservas/staticfiles"
+    <Directory "/opt/repos/reservas/staticfiles">
+        Require all granted
+    </Directory>
+</VirtualHost>


### PR DESCRIPTION
Configura un **VirtualHost** para que todas las peticiones direccionadas a `/reservas` sean redirigidas a la aplicación de `reservas`. Específicamente, al **contenedor Docker de Django**.
