### PR TITLE
Ocultamiento de cursor en vistas de TV

### DIFF
--- a/static/apps/reservas/css/tv.css
+++ b/static/apps/reservas/css/tv.css
@@ -6,6 +6,8 @@ body {
     color: black;
     /* Deshabilitación de scroll vertical */
     overflow-y: hidden;
+    /* Ocultamiento del cursor */
+    cursor: none;
 }
 
 /* Títulos */


### PR DESCRIPTION
Se oculta el cursor en las vistas de TV, para evitar su constante visualización.
