### PR TITLE
Configuración de color de texto en eventos, para vistas de TV

### DIFF
--- a/static/apps/reservas/css/tv.css
+++ b/static/apps/reservas/css/tv.css
@@ -48,8 +48,6 @@ div.fc-view-container {
 .fc-event {
     /* Tamaño normal de la fuente de los eventos */
     font-size: 1em;
-    /* Color del texto del evento: Negro */
-    color: black;
     /* Fuente de los eventos en negrita */
     font-weight: bold;
     /* Fuente de los eventos sin subrayado */

--- a/templates/app_reservas/base_tv.html
+++ b/templates/app_reservas/base_tv.html
@@ -62,5 +62,6 @@
     minTime: min_time_string,
     maxTime: max_time_string,
     eventBackgroundColor: '#87CEFA',
-    eventBorderColor: '#000000',
+    eventBorderColor: 'black',
+    eventTextColor: 'black',
 {% endblock fullcalendar_opciones %}


### PR DESCRIPTION
Se configura el color _negro_ para el **texto de los eventos**, en las vistas de TV.
