### PR TITLE
Creación de vista de TV para bedelías organizadas por cuerpos

### DIFF
--- a/app_reservas/models/bedelia.py
+++ b/app_reservas/models/bedelia.py
@@ -2,7 +2,10 @@
 
 from django.db import models
 
-from ..services.recursos import get_recursos_asociados
+from ..services.recursos import (
+    get_recursos_asociados,
+    get_recursos_asociados_por_cuerpo,
+)
 
 
 class Bedelia(models.Model):
@@ -55,3 +58,15 @@ class Bedelia(models.Model):
             instancia relacionada.
         """
         return get_recursos_asociados(self)
+
+    def get_recursos_por_cuerpo(self):
+        """
+        Retorna todos los recursos asociados a la instancia, separados por cuerpo.
+
+        Returns
+        -------
+        list of dicts
+            Lista de diccionarios, uno por cada cuerpo que presenta al menos una instancia
+            relacionada.
+        """
+        return get_recursos_asociados_por_cuerpo(self)

--- a/app_reservas/services/recursos.py
+++ b/app_reservas/services/recursos.py
@@ -65,3 +65,50 @@ def get_recursos_asociados(instancia):
                 )
 
     return recursos
+
+
+def get_recursos_asociados_por_cuerpo(instancia):
+    """Retorna todos los recursos asociados a la instancia, separados por cuerpo.
+
+    Genera una lista conformada por diccionarios, uno por cada cuerpo que presenta recursos
+    asociados. Cada uno de estos diccionarios indica el cuerpo y una lista con las instancias de
+    ese tipo que están relacionadas a la instancia.
+    En caso de que la instancia no tenga recursos relacionados de un cuerpo, el diccionario de este
+    cuerpo no es añadido a la lista.
+
+    Parameters
+    ----------
+    instancia : object
+        Instancia de la cual se obtienen sus recursos asociados.
+
+    Returns
+    -------
+    list of dicts
+        Lista de diccionarios, uno por cada cuerpo que presenta al menos una instancia relacionada.
+    """
+    lista_elementos = []
+    recursos_por_cuerpo = []
+
+    # Obtiene los recursos asociados a la instancia.
+    recursos = get_recursos_asociados(instancia)
+    # Combina en una única lista todos los elementos de los diferentes tipos de recurso asociados.
+    for tipo_recurso in recursos:
+        lista_elementos.extend(tipo_recurso['elementos'])
+
+    # Crea una lista con los cuerpos que presentan al menos un recurso relacionado (sin
+    # repeticiones), y la ordena por el número de cuerpo.
+    cuerpos = list({elemento.nivel.cuerpo for elemento in lista_elementos})
+    cuerpos.sort(key=lambda cuerpo: cuerpo.numero)
+
+    # Itera entre los cuerpos.
+    for cuerpo in cuerpos:
+        # Añade los recursos asociados del cuerpo actual.
+        recursos_por_cuerpo.append(
+            {
+                'cuerpo': cuerpo,
+                'elementos': [elemento for elemento in lista_elementos
+                              if elemento.nivel.cuerpo == cuerpo],
+            }
+        )
+
+    return recursos_por_cuerpo

--- a/app_reservas/urls.py
+++ b/app_reservas/urls.py
@@ -16,6 +16,7 @@ from .views import (
     SolicitudAulaView,
     SolicitudLaboratorioInformaticoView,
     SolicitudMaterialMultimediaView,
+    TvBedeliaCuerposDetailView,
     TvBedeliaDetailView,
     TvCuerposListView,
 )
@@ -106,5 +107,10 @@ urlpatterns = [
         r'^tv/bedelia/(?P<area_slug>[-\w]+)/$',
         TvBedeliaDetailView.as_view(),
         name='tv_area'
+    ),
+    url(
+        r'^tv/bedelia/(?P<area_slug>[-\w]+)/cuerpos/$',
+        TvBedeliaCuerposDetailView.as_view(),
+        name='tv_area_cuerpos'
     ),
 ]

--- a/app_reservas/views/__init__.py
+++ b/app_reservas/views/__init__.py
@@ -22,6 +22,7 @@ from .solicitud import (
     SolicitudMaterialMultimediaView,
 )
 from .tv import (
+    TvBedeliaCuerposDetailView,
     TvBedeliaDetailView,
     TvCuerposListView,
 )

--- a/app_reservas/views/tv.py
+++ b/app_reservas/views/tv.py
@@ -26,6 +26,23 @@ class TvBedeliaDetailView(DetailView):
         return get_object_or_404(Bedelia, area__slug=self.kwargs['area_slug'])
 
 
+class TvBedeliaCuerposDetailView(DetailView):
+    """
+    Vista de detalle para la visualización en TV de una instancia específica de Bedelia, con sus
+    recursos ordenados por cuerpo.
+    """
+    model = Bedelia
+    context_object_name = 'bedelia'
+    template_name = 'app_reservas/tv_bedelia_cuerpos.html'
+
+    def get_object(self, **kwargs):
+        """
+        Retorna la instancia de Bedelia que tiene asociada el área cuyo slug concuerda con el
+        parámetro 'area_slug' de la URL, o una respuesta 404 en caso de ser inválido.
+        """
+        return get_object_or_404(Bedelia, area__slug=self.kwargs['area_slug'])
+
+
 class TvCuerposListView(ListView):
     """
     Vista de lista para la visualización en TV de instancias de Cuerpo, ordenadas por número.

--- a/templates/app_reservas/tv_bedelia_cuerpos.html
+++ b/templates/app_reservas/tv_bedelia_cuerpos.html
@@ -1,0 +1,98 @@
+{% extends 'app_reservas/tv_bedelia.html' %}
+{% load static %}
+
+
+{% block contenido %}
+    <h1>Departamento de {{ bedelia.area }}</h1>
+
+    <div id="cuerpos">
+        {% for recursos_cuerpo in bedelia.get_recursos_por_cuerpo %}
+            <div id="cuerpo_{{ recursos_cuerpo.cuerpo.numero }}" class="contenedor-calendario">
+                <h1>{{ recursos_cuerpo.cuerpo }}</h1>
+
+                <div id="calendar_cuerpo_{{ recursos_cuerpo.cuerpo.numero }}" class="calendar"></div>
+            </div>
+        {% endfor %}
+    </div>
+{% endblock contenido %}
+
+
+{% block scripts %}
+    <script>
+        {% block fullcalendar_js_vars %}
+            {{ block.super }}
+        {% endblock fullcalendar_js_vars %}
+
+        $(document).ready(function() {
+            {% for recursos_cuerpo in bedelia.get_recursos_por_cuerpo %}
+                $("#calendar_cuerpo_{{ recursos_cuerpo.cuerpo.numero }}").fullCalendar({
+                    {% block fullcalendar_defaultView %}
+                        {{ block.super }}
+                    {% endblock fullcalendar_defaultView %}
+                    {% block fullcalendar_base_config %}
+                        {{ block.super }}
+                    {% endblock fullcalendar_base_config %}
+                    resourceColumns: [
+                        {
+                            group: true,
+                            labelText: 'Nivel',
+                            field: 'nivel'
+                        },
+                        {
+                            labelText: 'Recurso',
+                            field: 'title'
+                        },
+                    ],
+                    resources: [
+                        {% for recurso in recursos_cuerpo.elementos %}
+                            {
+                                id: '{{ recurso.id }}',
+                                nivel: '{{ recurso.nivel.get_nombre_corto }}',
+                                title: '{{ recurso.get_nombre_corto }}',
+                            },
+                        {% endfor %}
+                    ],
+                    eventSources: [
+                        {% for recurso in recursos_cuerpo.elementos %}
+                                {
+                                    url: '{% url "recurso_eventos_json" recurso.id %}',
+                                    {% if recurso.calendar_color %}
+                                        color: '{{ recurso.calendar_color }}',
+                                    {% endif %}
+                                },
+                        {% endfor %}
+                    ],
+                    header: {
+                        {% block fullcalendar_header %}
+                            left: '',
+                            center: 'title',
+                            right: '',
+                        {% endblock fullcalendar_header %}
+                    },
+                    titleFormat: "[{{ recursos_cuerpo.cuerpo }}]",
+                    {% block fullcalendar_loading_callback %}
+                        {{ block.super }}
+                    {% endblock fullcalendar_loading_callback %}
+                    {% block fullcalendar_opciones %}
+                        {{ block.super }}
+                    {% endblock %}
+                });
+            {% endfor %}
+
+            // Función que genera la transición de cuerpos, al ir quitando el último cuerpo del
+            // listado, y añadiéndolo al principio del mismo.
+            function generarTransicionCuerpo() {
+                var ultimo_cuerpo = $(".contenedor-calendario").last();
+                ultimo_cuerpo.hide();
+                $("#cuerpos").prepend(ultimo_cuerpo);
+                ultimo_cuerpo.fadeIn(1500);
+            }
+
+            // Ejecuta la transición sólo cuando hay más de un cuerpo disponible en la vista.
+            if ($(".contenedor-calendario").length > 1) {
+                // Establece la transición de cuerpos cada 10 segundos.
+                var timer = setInterval(generarTransicionCuerpo, 10000);
+            }
+        });
+    </script>
+{% endblock scripts %}


### PR DESCRIPTION
Se añade una vista de TV para **visualizar bedelías, con sus recursos organizados por cuerpo** en vez de tipo. Se puede acceder desde `tv/bedelia/<area_slug>/cuerpos`.
