### PR TITLE
Corrección en el ordenamiento del modelo Nivel

### DIFF
--- a/app_reservas/admin/cuerpo.py
+++ b/app_reservas/admin/cuerpo.py
@@ -20,5 +20,5 @@ class CuerpoAdmin(admin.ModelAdmin):
         """
         Obtiene el listado de niveles asociados a la instancia.
         """
-        return ", ".join([nivel.get_nombre_corto() for nivel in obj.nivel_set.order_by('numero')])
+        return ", ".join([nivel.get_nombre_corto() for nivel in obj.nivel_set.all()])
     _niveles.short_description = 'Niveles'

--- a/app_reservas/models/cuerpo.py
+++ b/app_reservas/models/cuerpo.py
@@ -38,4 +38,4 @@ class Cuerpo(models.Model):
         """
         Retorna el listado de niveles asociados a la instancia.
         """
-        return self.nivel_set.order_by('numero')
+        return self.nivel_set.all()

--- a/app_reservas/models/nivel.py
+++ b/app_reservas/models/nivel.py
@@ -16,6 +16,7 @@ class Nivel(models.Model):
         Información de la clase.
         """
         app_label = 'app_reservas'
+        ordering = ['cuerpo', 'numero']
         verbose_name = 'Nivel'
         verbose_name_plural = 'Niveles'
 


### PR DESCRIPTION
Se establece el ordenamiento (`ordering`) del modelo **Nivel**, para que sea dependiente de su cuerpo asociado, y su número.
