### PR TITLE
Modificación de fuente de texto para los calendarios en vistas de TV

### DIFF
--- a/static/apps/reservas/css/tv.css
+++ b/static/apps/reservas/css/tv.css
@@ -40,6 +40,10 @@ h1 {
     /* Eliminación de separación vertical */
     padding-top: 0px;
     padding-bottom: 0px;
+    /* Color del texto: Chalk Gray */
+    color: #F3F2F2;
+    /* Fuente en negrita */
+    font-weight: bold;
 }
 
 /* Contenedores de vistas de calendario */


### PR DESCRIPTION
Se modifica la fuente de texto para los **calendarios de las vistas de TV**, para una mejor visibilidad. Para esto, se establece el texto en negrita y color gris tiza.
