### PR TITLE
Generación de migración para ordenamiento de Aula y Nivel

### DIFF
--- a/app_reservas/migrations/0018_ordering_aula_nivel.py
+++ b/app_reservas/migrations/0018_ordering_aula_nivel.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """
+    Establecimiento de opción de ordenamiento para modelos 'Aula' y 'Nivel'.
+    """
+
+    dependencies = [
+        ('app_reservas', '0017_cuerpo_nombre'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='aula',
+            options={
+                'verbose_name_plural': 'Aulas',
+                'verbose_name': 'Aula',
+                'ordering': ['nivel', 'numero', 'nombre']
+            },
+        ),
+        migrations.AlterModelOptions(
+            name='nivel',
+            options={
+                'verbose_name_plural': 'Niveles',
+                'verbose_name': 'Nivel',
+                'ordering': ['cuerpo', 'numero']
+            },
+        ),
+    ]


### PR DESCRIPTION
Se añade la migración para el **ordenamiento de los modelos `Aula` y `Nivel`**. Este cambio complementa a los PRs #176 y #177.
