### PR TITLE
Filtrado por cuerpo y nivel para vista de TV de bedelía

### DIFF
--- a/app_reservas/views/tv.py
+++ b/app_reservas/views/tv.py
@@ -25,6 +25,25 @@ class TvBedeliaDetailView(DetailView):
         """
         return get_object_or_404(Bedelia, area__slug=self.kwargs['area_slug'])
 
+    def get_context_data(self, **kwargs):
+        """
+        Añade al contexto la información de cuerpo y nivel especificados
+        mediante parámetros GET.
+        """
+        # Obtiene la información de contexto base.
+        context = super(TvBedeliaDetailView, self).get_context_data(**kwargs)
+        # Obtiene los parámetros GET de cuerpo y nivel especificados.
+        cuerpo = self.request.GET.get('cuerpo')
+        nivel = self.request.GET.get('nivel')
+        # Convierte los parámetros a entero y los añade al contexto, sólo en
+        # caso de que se hayan especificado y sean números.
+        if cuerpo and cuerpo.isdigit():
+            context['cuerpo_solicitado'] = int(cuerpo)
+        if nivel and nivel.isdigit():
+            context['nivel_solicitado'] = int(nivel)
+        # Retorna el contexto modificado.
+        return context
+
 
 class TvBedeliaCuerposDetailView(DetailView):
     """

--- a/templates/app_reservas/tv_bedelia.html
+++ b/templates/app_reservas/tv_bedelia.html
@@ -35,23 +35,48 @@
                     {% block fullcalendar_base_config %}
                         {{ block.super }}
                     {% endblock fullcalendar_base_config %}
-                    resourceLabelText: "{{ tipo_recurso.nombre_singular }}",
+                    resourceColumns: [
+                        {
+                            group: true,
+                            labelText: 'Cuerpo',
+                            field: 'cuerpo'
+                        },
+                        {
+                            group: true,
+                            labelText: 'Nivel',
+                            field: 'nivel'
+                        },
+                        {
+                            labelText: '{{ tipo_recurso.nombre_singular }}',
+                            field: 'title'
+                        },
+                    ],
                     resources: [
                         {% for recurso in tipo_recurso.elementos %}
-                            {
-                                id: '{{ recurso.id }}',
-                                title: '{{ recurso }}',
-                            },
+                            {% if not cuerpo_solicitado or cuerpo_solicitado == recurso.nivel.cuerpo.numero %}
+                                {% if not nivel_solicitado or nivel_solicitado == recurso.nivel.numero %}
+                                    {
+                                        id: '{{ recurso.id }}',
+                                        nivel: '{{ recurso.nivel.get_nombre_corto }}',
+                                        cuerpo: '{{ recurso.nivel.cuerpo }}',
+                                        title: '{{ recurso.get_nombre_corto }}',
+                                    },
+                                {% endif %}
+                            {% endif %}
                         {% endfor %}
                     ],
                     eventSources: [
                         {% for recurso in tipo_recurso.elementos %}
-                            {
-                                url: '{% url "recurso_eventos_json" recurso.id %}',
-                                {% if recurso.calendar_color %}
-                                    color: '{{ recurso.calendar_color }}',
+                            {% if not cuerpo_solicitado or cuerpo_solicitado == recurso.nivel.cuerpo.numero %}
+                                {% if not nivel_solicitado or nivel_solicitado == recurso.nivel.numero %}
+                                    {
+                                        url: '{% url "recurso_eventos_json" recurso.id %}',
+                                        {% if recurso.calendar_color %}
+                                            color: '{{ recurso.calendar_color }}',
+                                        {% endif %}
+                                    },
                                 {% endif %}
-                            },
+                            {% endif %}
                         {% endfor %}
                     ],
                     header: {

--- a/templates/app_reservas/tv_bedelia_cuerpos.html
+++ b/templates/app_reservas/tv_bedelia_cuerpos.html
@@ -65,11 +65,10 @@
                     header: {
                         {% block fullcalendar_header %}
                             left: '',
-                            center: 'title',
+                            center: '',
                             right: '',
                         {% endblock fullcalendar_header %}
                     },
-                    titleFormat: "[{{ recursos_cuerpo.cuerpo }}]",
                     {% block fullcalendar_loading_callback %}
                         {{ block.super }}
                     {% endblock fullcalendar_loading_callback %}


### PR DESCRIPTION
Se permite el filtrado para la **vista de TV de bedelía**. Para esto, se hace uso de parámetros GET `cuerpo` y `nivel`. Por ejemplo: `reservas/tv/bedelia/civil/?cuerpo=2&nivel=1`.

Además, se reordenan los calendarios de la vista, para indicar **cuerpo**, **nivel** y **recurso** en diferentes columnas.
