### PR TITLE
Filtrado por nivel para vista de TV de cuerpos

### DIFF
--- a/app_reservas/views/tv.py
+++ b/app_reservas/views/tv.py
@@ -90,3 +90,19 @@ class TvCuerposListView(ListView):
         # Retorna los cuerpos, ordenados por número (el ordenamiento está definido a nivel de
         # modelo).
         return cuerpos.all()
+
+    def get_context_data(self, **kwargs):
+        """
+        Añade al contexto la información de nivel especificado mediante
+        parámetro GET.
+        """
+        # Obtiene la información de contexto base.
+        context = super(TvCuerposListView, self).get_context_data(**kwargs)
+        # Obtiene el parámetro GET de nivel especificado.
+        nivel = self.request.GET.get('nivel')
+        # Convierte el parámetro a entero y lo añade al contexto, sólo en caso
+        # de que se haya especificado y sea número.
+        if nivel and nivel.isdigit():
+            context['nivel_solicitado'] = int(nivel)
+        # Retorna el contexto modificado.
+        return context

--- a/templates/app_reservas/tv_cuerpos.html
+++ b/templates/app_reservas/tv_cuerpos.html
@@ -47,29 +47,33 @@
                     ],
                     resources: [
                         {% for nivel in cuerpo.get_niveles %}
-                            {% for tipo_recurso in nivel.get_recursos %}
-                                {% for recurso in tipo_recurso.elementos %}
-                                    {
-                                        id: '{{ recurso.id }}',
-                                        nivel: '{{ nivel.get_nombre_corto }}',
-                                        title: '{{ recurso.get_nombre_corto }}',
-                                    },
+                            {% if not nivel_solicitado or nivel_solicitado == nivel.numero %}
+                                {% for tipo_recurso in nivel.get_recursos %}
+                                    {% for recurso in tipo_recurso.elementos %}
+                                        {
+                                            id: '{{ recurso.id }}',
+                                            nivel: '{{ nivel.get_nombre_corto }}',
+                                            title: '{{ recurso.get_nombre_corto }}',
+                                        },
+                                    {% endfor %}
                                 {% endfor %}
-                            {% endfor %}
+                            {% endif %}
                         {% endfor %}
                     ],
                     eventSources: [
                         {% for nivel in cuerpo.get_niveles %}
-                            {% for tipo_recurso in nivel.get_recursos %}
-                                {% for recurso in tipo_recurso.elementos %}
-                                    {
-                                        url: '{% url "recurso_eventos_json" recurso.id %}',
-                                        {% if recurso.calendar_color %}
-                                            color: '{{ recurso.calendar_color }}',
-                                        {% endif %}
-                                    },
+                            {% if not nivel_solicitado or nivel_solicitado == nivel.numero %}
+                                {% for tipo_recurso in nivel.get_recursos %}
+                                    {% for recurso in tipo_recurso.elementos %}
+                                        {
+                                            url: '{% url "recurso_eventos_json" recurso.id %}',
+                                            {% if recurso.calendar_color %}
+                                                color: '{{ recurso.calendar_color }}',
+                                            {% endif %}
+                                        },
+                                    {% endfor %}
                                 {% endfor %}
-                            {% endfor %}
+                            {% endif %}
                         {% endfor %}
                     ],
                     header: {


### PR DESCRIPTION
Se añade el filtrado para la **vista de TV de cuerpos**, con respecto al **nivel**. Por ejemplo: `tv/cuerpos/?numero=2&nivel=1`.
