### PR TITLE
Uso de nombre corto del cuerpo en vista de TV de bedelía

### DIFF
--- a/templates/app_reservas/tv_bedelia.html
+++ b/templates/app_reservas/tv_bedelia.html
@@ -58,7 +58,7 @@
                                     {
                                         id: '{{ recurso.id }}',
                                         nivel: '{{ recurso.nivel.get_nombre_corto }}',
-                                        cuerpo: '{{ recurso.nivel.cuerpo }}',
+                                        cuerpo: '{{ recurso.nivel.cuerpo.get_nombre_corto }}',
                                         title: '{{ recurso.get_nombre_corto }}',
                                     },
                                 {% endif %}


### PR DESCRIPTION
Se hace uso del **nombre corto del cuerpo** en la vista de TV de bedelía, debido a que el nombre completo tiende a ser demasiado largo y es cortado dentro del calendario, por lo que no se visualiza completamente.
