### PR TITLE
Especificación de codificación UTF-8 en archivos restantes

### DIFF
--- a/app_facturacion/admin.py
+++ b/app_facturacion/admin.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from django.contrib import admin
 
 from .models import (

--- a/app_facturacion/urls.py
+++ b/app_facturacion/urls.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from django.conf.urls import url
 
 from . import views

--- a/app_reservas/apps.py
+++ b/app_reservas/apps.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from django.apps import AppConfig
 
 

--- a/app_reservas/signals/recurso.py
+++ b/app_reservas/signals/recurso.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from django.db.models.signals import post_save
 
 from ..models import Recurso

--- a/app_reservas/tasks.py
+++ b/app_reservas/tasks.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import os
 from celery import (
     group,

--- a/app_reservas/templatetags/navbar_tags.py
+++ b/app_reservas/templatetags/navbar_tags.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from django import template
 
 from ..models import (

--- a/app_reservas/urls.py
+++ b/app_reservas/urls.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from django.conf.urls import url
 
 from .views import (

--- a/reservas/celeryapp.py
+++ b/reservas/celeryapp.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import os
 
 from celery import Celery

--- a/reservas/urls.py
+++ b/reservas/urls.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 """reservas URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:

--- a/reservas/wsgi.py
+++ b/reservas/wsgi.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 """
 WSGI config for reservas project.
 


### PR DESCRIPTION
Se añade la especificación de **codificación UTF-8** a los archivos que no la tenían.
