### PR TITLE
Mejora en la exposición de enlace de 'Videoconferencias' para ALI

### DIFF
--- a/app_reservas/templatetags/navbar_tags.py
+++ b/app_reservas/templatetags/navbar_tags.py
@@ -4,7 +4,6 @@ from django import template
 
 from ..models import (
     Area,
-    Aula,
     Cuerpo,
     TipoLaboratorio,
 )
@@ -15,17 +14,9 @@ register = template.Library()
 
 @register.inclusion_tag('app_reservas/navbar.html')
 def obtener_informacion_navbar():
-    # Obtiene la instancia de la sala de videoconferencias.
-    sala_videoconferencias = Aula.objects.filter(
-        nivel__cuerpo__numero=6,
-        nivel__numero=2,
-        numero=1,
-    ).first()
-
     context = {
         'lista_cuerpos': Cuerpo.objects.all(),
         'lista_areas': Area.objects.all(),
         'lista_tipos_laboratorio': TipoLaboratorio.objects.all(),
-        'sala_videoconferencias': sala_videoconferencias,
     }
     return context

--- a/app_reservas/urls.py
+++ b/app_reservas/urls.py
@@ -3,6 +3,7 @@
 from django.conf.urls import url
 
 from .views import (
+    AliVideoconferenciasDetailView,
     AreaDetailView,
     AulaDetailView,
     CuerpoDetailView,
@@ -56,6 +57,11 @@ urlpatterns = [
         r'^recurso/(?P<pk>\d+)/eventos/$',
         recurso_eventos_json,
         name='recurso_eventos_json'
+    ),
+    url(
+        r'^ali/videoconferencias/$',
+        AliVideoconferenciasDetailView.as_view(),
+        name='ali_videoconferencias_detalle'
     ),
     url(
         r'^laboratorios/informatica/$',

--- a/app_reservas/views/__init__.py
+++ b/app_reservas/views/__init__.py
@@ -1,3 +1,4 @@
+from .ali import AliVideoconferenciasDetailView
 from .area import AreaDetailView
 from .aula import AulaDetailView
 from .cuerpo import CuerpoDetailView

--- a/app_reservas/views/ali.py
+++ b/app_reservas/views/ali.py
@@ -1,0 +1,21 @@
+# coding=utf-8
+
+from django.views.generic.detail import DetailView
+
+from ..models import Aula
+
+
+class AliVideoconferenciasDetailView(DetailView):
+    """
+    Vista de detalle para la sala de videoconferencias del ALI.
+    """
+    model = Aula
+    context_object_name = 'aula'
+
+    def get_object(self):
+        # Obtiene la instancia de la sala de videoconferencias.
+        return Aula.objects.filter(
+            nivel__cuerpo__numero=6,
+            nivel__numero=2,
+            numero=1,
+        ).first()

--- a/templates/app_reservas/navbar.html
+++ b/templates/app_reservas/navbar.html
@@ -99,7 +99,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="{% url 'aula_detalle' sala_videoconferencias.id %}">
+                            <a href="{% url 'ali_videoconferencias_detalle' %}">
                                 Videoconferencias
                             </a>
                         </li>


### PR DESCRIPTION
Se corrige la creación del enlace de **Videoconferencias** mediante la creación de una nueva vista. Se reduce así la carga a la base de datos producida en #191 con la modificación de los _templatetags_.
