### PR TITLE
Limpieza de referencias a 'laboratorio_electronica' en plantillas

### DIFF
--- a/templates/app_reservas/tipolaboratorio_detail.html
+++ b/templates/app_reservas/tipolaboratorio_detail.html
@@ -14,17 +14,17 @@
 
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
         <div class="panel panel-default">
-            <div class="panel-heading" role="tab" id="heading_listado_laboratorios_electronica">
+            <div class="panel-heading" role="tab" id="heading_listado_tipo_laboratorio">
                 <h4 class="panel-title">
                     <a role="button"
                        data-toggle="collapse"
                        data-parent="#accordion"
-                       href="#listado_laboratorios_electronica" aria-expanded="true" aria-controls="listado_laboratorios_electronica">
+                       href="#listado_tipo_laboratorio" aria-expanded="true" aria-controls="listado_tipo_laboratorio">
                         Listado de laboratorios de {{ tipo_laboratorio }}
                     </a>
                 </h4>
             </div>
-            <div id="listado_laboratorios_electronica" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="heading_listado_laboratorios_electronica">
+            <div id="listado_tipo_laboratorio" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="heading_listado_tipo_laboratorio">
                 <div class="panel-body">
                     <div class="table-responsive">
                         <table class="table table-condensed table-bordered table-striped">


### PR DESCRIPTION
Cambios faltantes en #188. No generaba problemas visuales, pero se mantiene el código actualizado y sin referencias a funciones antiguas.
