### PR TITLE
Utilización de 'page-header' para las cabeceras de página

### DIFF
--- a/static/apps/reservas/css/base.css
+++ b/static/apps/reservas/css/base.css
@@ -1,0 +1,5 @@
+/* Cabecera de página */
+.page-header {
+    /* Alineación horizontal: Centrado */
+    text-align: center;
+}

--- a/templates/app_reservas/ali_index.html
+++ b/templates/app_reservas/ali_index.html
@@ -7,8 +7,7 @@
 
 
 {% block contenido %}
-
-    <div class="page-header" style="text-align: center;">
+    <div class="page-header">
         <h1>Administración de Laboratorios Informáticos</h1>
     </div>
 
@@ -65,5 +64,4 @@
             Cuerpo 01, primer piso, frente a Bedelía de Sistemas.
         </div>
     </div>
-
 {% endblock contenido %}

--- a/templates/app_reservas/area_detail.html
+++ b/templates/app_reservas/area_detail.html
@@ -7,10 +7,9 @@
 
 
 {% block contenido %}
-    <h1 style="text-align: center;">{{ area }}</h1>
-
-    <br />
-    <br />
+    <div class="page-header">
+        <h1>{{ area }}</h1>
+    </div>
 
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
         <div class="panel panel-default">

--- a/templates/app_reservas/aula_detail.html
+++ b/templates/app_reservas/aula_detail.html
@@ -7,8 +7,10 @@
 
 
 {% block contenido %}
-    <h1 style="text-align: center;">{{ aula.get_nombre_corto }}</h1>
-    <h3 style="text-align: center;">{{ aula.nivel }}</h3>
+    <div class="page-header">
+        <h1>{{ aula.get_nombre_corto }}</h1>
+        <h3>{{ aula.nivel }}</h3>
+    </div>
 
     <div id="calendar" class="calendar"></div>
 {% endblock contenido %}

--- a/templates/app_reservas/base.html
+++ b/templates/app_reservas/base.html
@@ -22,7 +22,9 @@
     <!-- Pace.js theme -->
     <link rel="stylesheet" href='{% static 'PACE/themes/blue/pace-theme-flash.css' %}'>
 
-    {% block static_css %}{% endblock %}
+    {% block static_css %}
+        <link rel="stylesheet" href='{% static 'apps/reservas/css/base.css' %}'>
+    {% endblock %}
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>

--- a/templates/app_reservas/base_calendario.html
+++ b/templates/app_reservas/base_calendario.html
@@ -2,6 +2,8 @@
 {% load static %}
 
 {% block static_css %}
+    {{ block.super }}
+
     <link rel='stylesheet' href='{% static 'fullcalendar/dist/fullcalendar.min.css' %}' />
     <link rel='stylesheet' href='{% static 'fullcalendar-scheduler/dist/scheduler.min.css' %}' />
     <link rel="stylesheet" href='{% static 'bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css' %}' />
@@ -138,12 +140,17 @@
 
     <script>
         $(document).ready(function() {
-            var primer_dia_anio_actual = new Date(new Date().getFullYear(),
-                                                  0,
-                                                  1);
-            var ultimo_dia_anio_siguiente = new Date(new Date().getFullYear() + 1,
-                                                     11,
-                                                     31);
+            var anio_actual = new Date().getFullYear();
+            var primer_dia_anio_actual = new Date(
+                anio_actual,
+                0,
+                1
+            );
+            var ultimo_dia_anio_siguiente = new Date(
+                anio_actual + 1,
+                11,
+                31
+            );
 
             $('.fc-datepickerButton-button').datepicker({
                 format: 'dd/mm/yyyy',

--- a/templates/app_reservas/base_carrusel.html
+++ b/templates/app_reservas/base_carrusel.html
@@ -2,14 +2,16 @@
 {% load static %}
 
 {% block static_css %}
+    {{ block.super }}
+
     <link rel="stylesheet" href='{% static 'slick-carousel/slick/slick.css' %}'>
     <link rel="stylesheet" href='{% static 'slick-carousel/slick/slick-theme.css' %}'>
-{% endblock %}
+{% endblock static_css %}
 
 
 {% block static_js_body %}
     <script src='{% static 'slick-carousel/slick/slick.min.js' %}'></script>
-{% endblock %}
+{% endblock static_js_body %}
 
 
 {% block scripts %}
@@ -28,4 +30,4 @@
             );
         });
     </script>
-{% endblock %}
+{% endblock scripts %}

--- a/templates/app_reservas/base_tv.html
+++ b/templates/app_reservas/base_tv.html
@@ -1,7 +1,6 @@
 {% extends 'app_reservas/base_calendario.html' %}
 {% load static %}
 
-
 {% block head_meta %}
     <!--
     Refresca la página cada 10 minutos. Esto permite la visualizacion de nuevos

--- a/templates/app_reservas/cuerpo_detail.html
+++ b/templates/app_reservas/cuerpo_detail.html
@@ -7,10 +7,9 @@
 
 
 {% block contenido %}
-    <h1 style="text-align: center;">{{ cuerpo }}</h1>
-
-    <br />
-    <br />
+    <div class="page-header">
+        <h1>{{ cuerpo }}</h1>
+    </div>
 
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
         {% for nivel in cuerpo.get_niveles %}

--- a/templates/app_reservas/index.html
+++ b/templates/app_reservas/index.html
@@ -7,8 +7,9 @@
 
 
 {% block contenido %}
-
-    <h1 style="text-align: center;">Gestión de recursos</h1>
+    <div class="page-header">
+        <h1>Gestión de recursos</h1>
+    </div>
 
     {% if carrusel_imagenes %}
         <div style="width: 90%; max-width: {{ carrusel.ancho_maximo}}px; margin: 0 auto; padding: 30px 0;">
@@ -27,5 +28,4 @@
         ¡Bienvenido! En este sitio podrá consultar las reservas de aulas pertenecientes a la Facultad Regional Mendoza,
         Universidad Tecnológica Nacional.
     </p>
-
 {% endblock contenido %}

--- a/templates/app_reservas/laboratorio_detail.html
+++ b/templates/app_reservas/laboratorio_detail.html
@@ -7,8 +7,10 @@
 
 
 {% block contenido %}
-    <h1 style="text-align: center;">{{ laboratorio }}</h1>
-    <h3 style="text-align: center;">{{ laboratorio.nivel }}</h3>
+    <div class="page-header">
+        <h1>{{ laboratorio }}</h1>
+        <h3>{{ laboratorio.nivel }}</h3>
+    </div>
 
     <div id="calendar" class="calendar"></div>
 {% endblock contenido %}

--- a/templates/app_reservas/laboratorioinformatico_detail.html
+++ b/templates/app_reservas/laboratorioinformatico_detail.html
@@ -7,8 +7,10 @@
 
 
 {% block contenido %}
-    <h1 style="text-align: center;">{{ laboratorio }}</h1>
-    <h3 style="text-align: center;">{{ laboratorio.nivel }}</h3>
+    <div class="page-header">
+        <h1>{{ laboratorio }}</h1>
+        <h3>{{ laboratorio.nivel }}</h3>
+    </div>
 
     <div id="calendar" class="calendar"></div>
 {% endblock contenido %}

--- a/templates/app_reservas/laboratorioinformatico_list.html
+++ b/templates/app_reservas/laboratorioinformatico_list.html
@@ -7,10 +7,9 @@
 
 
 {% block contenido %}
-    <h1 style="text-align: center;">Laboratorios informáticos</h1>
-
-    <br/>
-    <br/>
+    <div class="page-header">
+        <h1>Laboratorios informáticos</h1>
+    </div>
 
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
         <div class="panel panel-default">

--- a/templates/app_reservas/nivel_detail.html
+++ b/templates/app_reservas/nivel_detail.html
@@ -7,11 +7,10 @@
 
 
 {% block contenido %}
-    <h1 style="text-align: center;">{{ nivel.get_nombre_corto }}</h1>
-    <h3 style="text-align: center;">{{ nivel.cuerpo }}</h3>
-
-    <br/>
-    <br/>
+    <div class="page-header">
+        <h1>{{ nivel.get_nombre_corto }}</h1>
+        <h3>{{ nivel.cuerpo }}</h3>
+    </div>
 
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
         {% for tipo_recurso in nivel.get_recursos %}

--- a/templates/app_reservas/recursoali_detail.html
+++ b/templates/app_reservas/recursoali_detail.html
@@ -6,7 +6,9 @@
 {% endblock title %}
 
 {% block contenido %}
-    <h1 style="text-align: center;">{{ recurso }}</h1>
+    <div class="page-header">
+        <h1>{{ recurso }}</h1>
+    </div>
 
     <div id="calendar" class="calendar"></div>
 {% endblock contenido %}

--- a/templates/app_reservas/tipolaboratorio_detail.html
+++ b/templates/app_reservas/tipolaboratorio_detail.html
@@ -7,10 +7,9 @@
 
 
 {% block contenido %}
-    <h1 style="text-align: center;">Laboratorios de {{ tipo_laboratorio }}</h1>
-
-    <br/>
-    <br/>
+    <div class="page-header">
+        <h1>Laboratorios de {{ tipo_laboratorio }}</h1>
+    </div>
 
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
         <div class="panel panel-default">

--- a/templates/app_reservas/tiporecursoali_detail.html
+++ b/templates/app_reservas/tiporecursoali_detail.html
@@ -5,11 +5,11 @@
     {{ tipo_recurso.nombre_plural }}
 {% endblock title %}
 
-{% block contenido %}
-    <h1 style="text-align: center;">{{ tipo_recurso.nombre_plural }}</h1>
 
-    <br/>
-    <br/>
+{% block contenido %}
+    <div class="page-header">
+        <h1>{{ tipo_recurso.nombre_plural }}</h1>
+    </div>
 
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
         <div class="panel panel-default">

--- a/templates/app_reservas/tv_visor_cuerpos.html
+++ b/templates/app_reservas/tv_visor_cuerpos.html
@@ -1,7 +1,6 @@
 {% extends 'app_reservas/tv_visor.html' %}
 {% load static %}
 
-
 {% block contenido %}
     <h1>{{ visor.get_nombre_corto }}</h1>
 


### PR DESCRIPTION
Se hace uso del [**Page header**](https://getbootstrap.com/components/#page-header) de _Bootstrap_ para estandarizar y simplificar el formato de las cabeceras de página.
