### PR TITLE
Cambio de nombre en sección de información general del ALI

### DIFF
--- a/templates/app_reservas/navbar.html
+++ b/templates/app_reservas/navbar.html
@@ -90,7 +90,7 @@
                     <ul class="dropdown-menu">
                         <li>
                             <a href="{% url 'ali_index' %}">
-                                Página principal
+                                Información general
                             </a>
                         </li>
                         <li>


### PR DESCRIPTION
Se cambia en el _navbar_ el nombre de la sección de información del ALI, de **Página principal** a **Información general**.
