### PR TITLE
Corrección de bounce en elemento collapse de la página del ALI

### DIFF
--- a/templates/app_reservas/ali_index.html
+++ b/templates/app_reservas/ali_index.html
@@ -26,7 +26,7 @@
 
     <div class="col-sm-10 col-sm-offset-1">
         <div class="list-group col-sm-4">
-            <a href="#" class="list-group-item active" data-toggle="collapse" data-target="#lista-recursos-ali">
+            <a class="list-group-item active" data-toggle="collapse" data-target="#lista-recursos-ali">
                 Listado de recursos
                 <span class="glyphicon glyphicon-menu-hamburger pull-right"></span>
             </a>


### PR DESCRIPTION
Se corrige el comportamiento en la **página de información del ALI**, en donde el expandir/contraer el listado de recursos generaba un scroll hacia la parte superior de la página.
