### PR TITLE
Corrección de espacio en blanco, en navbar

### DIFF
--- a/templates/app_reservas/navbar.html
+++ b/templates/app_reservas/navbar.html
@@ -14,7 +14,7 @@
                 <li>
                     <a href="{% url 'index' %}">
                         <i class="fa fa-home fa-lg fa-fw"></i>
-                        &nbsp;<span class="hidden-sm">Inicio</span>
+                        <span class="hidden-sm">&nbsp;Inicio</span>
                     </a>
                 </li>
                 <li class="dropdown">
@@ -141,7 +141,7 @@
                 <li>
                     <a href='https://github.com/utn-frm-si/reservas'
                        target='_blank'>
-                        <i class="fa fa- fa-github fa-lg fa-fw"></i>&nbsp;<span class="hidden-sm">GitHub</span>
+                        <i class="fa fa-github fa-lg fa-fw"></i>&nbsp;<span class="hidden-sm">GitHub</span>
                     </a>
                 </li>
             </ul>


### PR DESCRIPTION
Se corrige el elemento **Inicio** del _navbar_, que presentaba un espacio en blanco entre el ícono y el texto **Inicio**, aunque se mostrara sólo el ícono.
